### PR TITLE
feat(route): GitHub issue creation and intent router (#4)

### DIFF
--- a/src/__tests__/route.test.ts
+++ b/src/__tests__/route.test.ts
@@ -1,0 +1,378 @@
+/**
+ * Tests for route.ts — intent router with GitHub issue creation.
+ * Issue #4 — NostraAIAgent.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { Intent } from '../models.js';
+import type { OpenClawConfig } from '../config.js';
+
+// Hoist mock functions so they're initialized before vi.mock factories run
+const { mockCreate, mockSpeak, mockIsDuplicate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+  mockSpeak: vi.fn(),
+  mockIsDuplicate: vi.fn(),
+}));
+
+// Mock @octokit/rest with the class returning our mock
+vi.mock('@octokit/rest', () => ({
+  Octokit: vi.fn(() => ({
+    issues: {
+      create: mockCreate,
+    },
+  })),
+}));
+
+// Mock dependencies
+vi.mock('../dedup.js', () => ({
+  isDuplicate: mockIsDuplicate,
+}));
+
+vi.mock('../speak.js', () => ({
+  speak: mockSpeak,
+}));
+
+// Import after mocks
+import { routeIntent } from '../route.js';
+import { MeetingSession } from '../session.js';
+
+const mockConfig: OpenClawConfig = {
+  instanceName: 'test-bot',
+  skribbyApiKey: 'test-skribby',
+  elevenLabsApiKey: 'test-eleven',
+  anthropicApiKey: 'test-anthropic',
+  githubToken: 'ghp_test123',
+  githubRepo: 'owner/repo',
+  telegramBotToken: null,
+  telegramChatId: null,
+  confidenceThreshold: 0.85,
+};
+
+const createIntent = (overrides: Partial<Intent> = {}): Intent => ({
+  id: 'intent-1',
+  type: 'BUG',
+  text: 'Users cannot log in on mobile',
+  owner: 'Tom',
+  deadline: null,
+  priority: 'high',
+  confidence: 0.92,
+  sourceQuote: 'There is a bug where users cannot log in on mobile',
+  ...overrides,
+});
+
+describe('routeIntent', () => {
+  let session: MeetingSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    session = new MeetingSession('https://meet.google.com/abc', mockConfig);
+    mockIsDuplicate.mockReturnValue(false);
+    mockSpeak.mockResolvedValue(undefined);
+    mockCreate.mockResolvedValue({
+      data: {
+        html_url: 'https://github.com/owner/repo/issues/42',
+        number: 42,
+        title: 'Bug: Users cannot log in on mobile',
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('deduplication', () => {
+    it('should skip duplicate intents without action', async () => {
+      mockIsDuplicate.mockReturnValue(true);
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockIsDuplicate).toHaveBeenCalledWith(intent, session);
+      expect(session.intents).toHaveLength(0);
+      expect(mockCreate).not.toHaveBeenCalled();
+      expect(mockSpeak).not.toHaveBeenCalled();
+    });
+
+    it('should add non-duplicate intent to session', async () => {
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(session.intents).toContain(intent);
+    });
+  });
+
+  describe('GitHub configuration checks', () => {
+    it('should speak error when githubToken is missing', async () => {
+      const configNoToken = { ...mockConfig, githubToken: null };
+      const intent = createIntent();
+
+      await routeIntent(intent, session, configNoToken);
+
+      expect(mockSpeak).toHaveBeenCalledWith(
+        "I don't have GitHub connected. I noted it locally.",
+        configNoToken,
+      );
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should speak error when githubRepo is missing', async () => {
+      const configNoRepo = { ...mockConfig, githubRepo: null };
+      const intent = createIntent();
+
+      await routeIntent(intent, session, configNoRepo);
+
+      expect(mockSpeak).toHaveBeenCalledWith(
+        "I don't have GitHub connected. I noted it locally.",
+        configNoRepo,
+      );
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confidence threshold', () => {
+    it('should skip issue creation when confidence below threshold', async () => {
+      const intent = createIntent({ confidence: 0.70 });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockSpeak).toHaveBeenCalledWith(
+        expect.stringContaining('confidence'),
+        mockConfig,
+      );
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should create issue when confidence equals threshold', async () => {
+      const intent = createIntent({ confidence: 0.85 });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalled();
+    });
+
+    it('should create issue when confidence exceeds threshold', async () => {
+      const intent = createIntent({ confidence: 0.95 });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+
+  describe('GitHub issue creation for BUG', () => {
+    it('should create GitHub issue with correct API call', async () => {
+      const intent = createIntent({ type: 'BUG', text: 'Login fails on mobile' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        title: expect.stringContaining('Login fails on mobile'),
+        body: expect.any(String),
+        labels: expect.arrayContaining(['bug']),
+      });
+    });
+
+    it('should add critical label for critical priority', async () => {
+      const intent = createIntent({ type: 'BUG', priority: 'critical' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labels: expect.arrayContaining(['bug', 'priority:critical']),
+        }),
+      );
+    });
+
+    it('should add high priority label', async () => {
+      const intent = createIntent({ type: 'BUG', priority: 'high' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labels: expect.arrayContaining(['bug', 'priority:high']),
+        }),
+      );
+    });
+
+    it('should add created issue to session on success', async () => {
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(session.createdIssues).toHaveLength(1);
+      expect(session.createdIssues[0]).toEqual({
+        intentText: intent.text,
+        issueUrl: 'https://github.com/owner/repo/issues/42',
+        issueNumber: 42,
+        title: 'Bug: Users cannot log in on mobile',
+      });
+    });
+
+    it('should speak confirmation on successful issue creation', async () => {
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockSpeak).toHaveBeenCalledWith(
+        expect.stringContaining('#42'),
+        mockConfig,
+      );
+    });
+  });
+
+  describe('GitHub issue creation for FEATURE', () => {
+    it('should create GitHub issue with enhancement label', async () => {
+      const intent = createIntent({ type: 'FEATURE', text: 'Add dark mode' });
+      mockCreate.mockResolvedValue({
+        data: {
+          html_url: 'https://github.com/owner/repo/issues/43',
+          number: 43,
+          title: 'Feature: Add dark mode',
+        },
+      });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        title: expect.stringContaining('Add dark mode'),
+        body: expect.any(String),
+        labels: expect.arrayContaining(['enhancement']),
+      });
+    });
+  });
+
+  describe('non-GitHub intent types', () => {
+    it('should add TODO intent without creating GitHub issue', async () => {
+      const intent = createIntent({ type: 'TODO' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(session.intents).toContain(intent);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should add DECISION intent without creating GitHub issue', async () => {
+      const intent = createIntent({ type: 'DECISION' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(session.intents).toContain(intent);
+      expect(session.decisions).toContain(intent.text);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('should add MEETING_REQUEST intent without creating GitHub issue', async () => {
+      const intent = createIntent({ type: 'MEETING_REQUEST' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(session.intents).toContain(intent);
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should speak error on GitHub API failure', async () => {
+      mockCreate.mockRejectedValue(new Error('API Error'));
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockSpeak).toHaveBeenCalledWith(
+        expect.stringContaining('failed'),
+        mockConfig,
+      );
+      expect(session.createdIssues).toHaveLength(0);
+    });
+
+    it('should not throw on GitHub API failure', async () => {
+      mockCreate.mockRejectedValue(new Error('API Error'));
+      const intent = createIntent();
+
+      await expect(routeIntent(intent, session, mockConfig)).resolves.not.toThrow();
+    });
+  });
+
+  describe('issue body content', () => {
+    it('should include source quote in issue body', async () => {
+      const intent = createIntent({
+        sourceQuote: 'The login button does not work on iOS',
+      });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('The login button does not work on iOS'),
+        }),
+      );
+    });
+
+    it('should include owner in issue body when present', async () => {
+      const intent = createIntent({ owner: 'Alice' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('Alice'),
+        }),
+      );
+    });
+
+    it('should include deadline in issue body when present', async () => {
+      const intent = createIntent({ deadline: '2026-04-01' });
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('2026-04-01'),
+        }),
+      );
+    });
+
+    it('should include session URL in issue body', async () => {
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('https://meet.google.com/abc'),
+        }),
+      );
+    });
+
+    it('should include MeetingClaw attribution in body', async () => {
+      const intent = createIntent();
+
+      await routeIntent(intent, session, mockConfig);
+
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining('MeetingClaw'),
+        }),
+      );
+    });
+  });
+
+  describe('speak is fire-and-forget', () => {
+    it('should not await speak calls (fire-and-forget)', async () => {
+      // speak is mocked to return a Promise that rejects
+      mockSpeak.mockRejectedValue(new Error('TTS failed'));
+      const intent = createIntent();
+
+      // This should not throw even though speak rejects
+      await expect(routeIntent(intent, session, mockConfig)).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,16 +1,180 @@
 /**
- * Intent router: maps intents to OpenClaw tools (GitHub, Telegram).
+ * Intent router: maps intents to GitHub issue creation.
  * Issue #4 — NostraAIAgent.
- * Stub — full implementation in feature/issue-4-github-issues branch.
+ *
+ * Routes BUG and FEATURE intents to GitHub Issues API.
+ * Other intent types are tracked in session but not externally routed.
  */
 
-import type { Intent } from './models.js';
+import { Octokit } from '@octokit/rest';
+import type { Intent, CreatedIssue } from './models.js';
 import type { MeetingSession } from './session.js';
+import type { OpenClawConfig } from './config.js';
+import { isDuplicate } from './dedup.js';
+import { speak } from './speak.js';
 
+/**
+ * Route an intent to the appropriate action handler.
+ * For BUG/FEATURE: creates GitHub issues with deduplication.
+ * For other types: adds to session for tracking.
+ */
 export async function routeIntent(
-  _intent: Intent,
-  _session: MeetingSession,
+  intent: Intent,
+  session: MeetingSession,
+  config: OpenClawConfig,
 ): Promise<void> {
-  // TODO: Issue #4 — route to GitHub, Telegram, etc.
-  throw new Error('Not implemented — see Issue #4');
+  // Deduplication check first
+  if (isDuplicate(intent, session)) {
+    return;
+  }
+
+  // Track intent in session
+  session.addIntent(intent);
+
+  // Route based on intent type
+  if (intent.type === 'BUG' || intent.type === 'FEATURE') {
+    await handleGitHubIntent(intent, session, config);
+  }
+  // TODO: Future routing for MEETING_REQUEST → Calendar, etc.
+}
+
+/**
+ * Handle BUG and FEATURE intents by creating GitHub issues.
+ */
+async function handleGitHubIntent(
+  intent: Intent,
+  session: MeetingSession,
+  config: OpenClawConfig,
+): Promise<void> {
+  // Check GitHub configuration
+  if (!config.githubToken || !config.githubRepo) {
+    speak(
+      "I don't have GitHub connected. I noted it locally.",
+      config,
+    ).catch(console.error);
+    return;
+  }
+
+  // Check confidence threshold
+  if (intent.confidence < config.confidenceThreshold) {
+    speak(
+      `I detected a ${intent.type.toLowerCase()} but my confidence is low. Please confirm: "${intent.text}"`,
+      config,
+    ).catch(console.error);
+    return;
+  }
+
+  try {
+    const issue = await createGitHubIssue(intent, session, config);
+    session.addCreatedIssue(issue);
+    speak(
+      `Created GitHub issue #${issue.issueNumber}: ${issue.title}`,
+      config,
+    ).catch(console.error);
+  } catch (err) {
+    console.error('GitHub issue creation failed:', err);
+    speak(
+      `GitHub issue creation failed. I'll include this in the meeting summary instead.`,
+      config,
+    ).catch(console.error);
+  }
+}
+
+/**
+ * Create a GitHub issue from an intent.
+ */
+async function createGitHubIssue(
+  intent: Intent,
+  session: MeetingSession,
+  config: OpenClawConfig,
+): Promise<CreatedIssue> {
+  const title = formatIssueTitle(intent);
+  const body = formatIssueBody(intent, session);
+  const labels = getLabelsForIntent(intent);
+
+  const [owner, repo] = config.githubRepo!.split('/');
+  const octokit = new Octokit({ auth: config.githubToken });
+
+  const response = await octokit.issues.create({
+    owner,
+    repo,
+    title,
+    body,
+    labels,
+  });
+
+  return {
+    intentText: intent.text,
+    issueUrl: response.data.html_url,
+    issueNumber: response.data.number,
+    title: response.data.title,
+  };
+}
+
+/**
+ * Format the issue title based on intent type.
+ */
+function formatIssueTitle(intent: Intent): string {
+  const prefix = intent.type === 'BUG' ? 'Bug' : 'Feature';
+  return `${prefix}: ${intent.text}`;
+}
+
+/**
+ * Format the issue body with context from the meeting.
+ */
+function formatIssueBody(intent: Intent, session: MeetingSession): string {
+  const lines: string[] = [
+    '## Description',
+    intent.text,
+    '',
+  ];
+
+  if (intent.sourceQuote) {
+    lines.push('## Source Quote');
+    lines.push(`> ${intent.sourceQuote}`);
+    lines.push('');
+  }
+
+  if (intent.owner) {
+    lines.push(`**Mentioned by**: ${intent.owner}`);
+  }
+
+  if (intent.priority !== 'medium') {
+    lines.push(`**Priority**: ${intent.priority}`);
+  }
+
+  if (intent.deadline) {
+    lines.push(`**Deadline**: ${intent.deadline}`);
+  }
+
+  if (session.url) {
+    lines.push(`**Meeting**: ${session.url}`);
+  }
+
+  lines.push('');
+  lines.push('---');
+  lines.push('*Automatically created by MeetingClaw*');
+
+  return lines.join('\n');
+}
+
+/**
+ * Get GitHub labels based on intent type and priority.
+ */
+function getLabelsForIntent(intent: Intent): string[] {
+  const labels: string[] = [];
+
+  // Type label
+  if (intent.type === 'BUG') {
+    labels.push('bug');
+  } else if (intent.type === 'FEATURE') {
+    labels.push('enhancement');
+  }
+
+  // Priority label for high/critical
+  if (intent.priority === 'critical' || intent.priority === 'high') {
+    labels.push(`priority:${intent.priority}`);
+  }
+
+  return labels;
 }


### PR DESCRIPTION
## Summary

Implements the intent action router. When a BUG or FEATURE intent is detected with sufficient confidence, it creates a GitHub issue in the OpenClaw-configured repo and speaks a confirmation. DECISION intents are stored in session state. Duplicate intents are skipped via dedup check.

## Changes

- `src/route.ts` — full implementation: dedup check, GitHub issue creation via @octokit/rest, fire-and-forget speak calls, DECISION storage, graceful failure handling
- `src/__tests__/route.test.ts` — 24 new tests covering all paths

## Testing

```
npm test -> 132/132 passing (108 existing + 24 new)
```

Closes #4