### PR TITLE
feat: Skribby WebSocket transcript client (#2)

### DIFF
--- a/src/listen.test.ts
+++ b/src/listen.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { TranscriptSegment } from './models.js';
+import type { OnSegmentCallback } from './listen.js';
+
+// ---------------------------------------------------------------------------
+// Mock WebSocket
+// ---------------------------------------------------------------------------
+
+class MockWebSocket extends EventEmitter {
+  readonly url: string;
+  readonly options: Record<string, unknown>;
+
+  constructor(url: string, options?: Record<string, unknown>) {
+    super();
+    this.url = url;
+    this.options = options ?? {};
+    // store for assertions
+    instances.push(this);
+  }
+}
+
+let instances: MockWebSocket[] = [];
+
+vi.mock('ws', () => ({
+  default: vi.fn().mockImplementation((url: string, opts?: Record<string, unknown>) => {
+    return new MockWebSocket(url, opts);
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mock is set up
+// ---------------------------------------------------------------------------
+
+const { streamTranscript } = await import('./listen.js');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function latestWs(): MockWebSocket {
+  const ws = instances[instances.length - 1];
+  if (!ws) throw new Error('No MockWebSocket instance found');
+  return ws;
+}
+
+function sendMessage(ws: MockWebSocket, data: unknown): void {
+  ws.emit('message', Buffer.from(JSON.stringify(data)));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('streamTranscript', () => {
+  beforeEach(() => {
+    instances = [];
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -----------------------------------------------------------------------
+  // Connection
+  // -----------------------------------------------------------------------
+
+  it('connects with correct URL and authorization header', () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    streamTranscript('bot-123', 'sk-test-key', onSegment);
+
+    const ws = latestWs();
+    expect(ws.url).toBe('wss://api.skribby.io/v1/bots/bot-123/transcript');
+    expect(ws.options).toEqual(
+      expect.objectContaining({
+        headers: { Authorization: 'Bearer sk-test-key' },
+      }),
+    );
+  });
+
+  // -----------------------------------------------------------------------
+  // Message parsing
+  // -----------------------------------------------------------------------
+
+  it('parses incoming message and calls onSegment with TranscriptSegment', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
+    streamTranscript('bot-1', 'key', onSegment);
+
+    const ws = latestWs();
+    const message = { text: 'Hello world', speaker: 'Alice', timestamp: 1000 };
+    sendMessage(ws, message);
+
+    // Let microtasks flush
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onSegment).toHaveBeenCalledOnce();
+    const segment: TranscriptSegment = onSegment.mock.calls[0][0];
+    expect(segment).toEqual({
+      text: 'Hello world',
+      speaker: 'Alice',
+      timestamp: 1000,
+    });
+  });
+
+  it('defaults speaker to null when missing from message', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
+    streamTranscript('bot-1', 'key', onSegment);
+
+    const ws = latestWs();
+    sendMessage(ws, { text: 'No speaker', timestamp: 2000 });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onSegment).toHaveBeenCalledOnce();
+    expect(onSegment.mock.calls[0][0].speaker).toBeNull();
+  });
+
+  // -----------------------------------------------------------------------
+  // Malformed messages
+  // -----------------------------------------------------------------------
+
+  it('logs error on malformed JSON but does not crash', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    streamTranscript('bot-1', 'key', onSegment);
+    const ws = latestWs();
+
+    // Send invalid JSON
+    ws.emit('message', Buffer.from('not valid json'));
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onSegment).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to parse transcript message:',
+      expect.any(String),
+    );
+
+    errorSpy.mockRestore();
+  });
+
+  it('logs error on valid JSON that fails Zod validation', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    streamTranscript('bot-1', 'key', onSegment);
+    const ws = latestWs();
+
+    // Missing required 'text' field
+    sendMessage(ws, { speaker: 'Bob', timestamp: 100 });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onSegment).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+
+    errorSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Clean close
+  // -----------------------------------------------------------------------
+
+  it('resolves on clean close (code 1000) without reconnecting', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    const promise = streamTranscript('bot-1', 'key', onSegment);
+
+    const ws = latestWs();
+    ws.emit('close', 1000);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(instances).toHaveLength(1); // no reconnect
+  });
+
+  // -----------------------------------------------------------------------
+  // Reconnect on unexpected close
+  // -----------------------------------------------------------------------
+
+  it('reconnects with exponential backoff on unexpected close (up to 3 times)', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    const promise = streamTranscript('bot-1', 'key', onSegment);
+
+    // First connection -- unexpected close
+    expect(instances).toHaveLength(1);
+    latestWs().emit('close', 1006);
+
+    // Advance past 1s backoff
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(instances).toHaveLength(2);
+
+    // Second connection -- unexpected close
+    latestWs().emit('close', 1006);
+
+    // Advance past 2s backoff
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(instances).toHaveLength(3);
+
+    // Third connection -- unexpected close
+    latestWs().emit('close', 1006);
+
+    // Advance past 4s backoff
+    await vi.advanceTimersByTimeAsync(4000);
+    expect(instances).toHaveLength(4);
+
+    // Fourth connection -- unexpected close, retries exhausted
+    latestWs().emit('close', 1006);
+
+    await expect(promise).rejects.toThrow(
+      'WebSocket closed unexpectedly (code 1006) after 3 retries',
+    );
+  });
+
+  it('reconnects then resolves if subsequent connection closes cleanly', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    const promise = streamTranscript('bot-1', 'key', onSegment);
+
+    // First connection -- unexpected close
+    latestWs().emit('close', 1006);
+
+    // Advance past 1s backoff
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(instances).toHaveLength(2);
+
+    // Second connection closes cleanly
+    latestWs().emit('close', 1000);
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  // -----------------------------------------------------------------------
+  // Callback errors
+  // -----------------------------------------------------------------------
+
+  it('does not crash when onSegment callback throws', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>().mockRejectedValue(new Error('callback boom'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    streamTranscript('bot-1', 'key', onSegment);
+    const ws = latestWs();
+
+    sendMessage(ws, { text: 'test', speaker: null, timestamp: 500 });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onSegment).toHaveBeenCalledOnce();
+    // Stream should still be alive -- verify by sending another message
+    sendMessage(ws, { text: 'still alive', speaker: null, timestamp: 600 });
+
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(onSegment).toHaveBeenCalledTimes(2);
+
+    errorSpy.mockRestore();
+  });
+
+  // -----------------------------------------------------------------------
+  // Error event handling
+  // -----------------------------------------------------------------------
+
+  it('swallows WebSocket error events without crashing', async () => {
+    const onSegment = vi.fn<OnSegmentCallback>();
+    streamTranscript('bot-1', 'key', onSegment);
+
+    const ws = latestWs();
+
+    // Should not throw
+    ws.emit('error', new Error('connection refused'));
+
+    // The close event follows an error -- trigger reconnect path
+    ws.emit('close', 1006);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(instances).toHaveLength(2);
+  });
+});

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -1,18 +1,107 @@
 /**
  * Skribby WebSocket: receive live transcript stream.
- * Issue #2 — Smokefarmer.
- * Stub — full implementation in feature/issue-2-websocket-transcript branch.
+ * Issue #2 -- connects to Skribby's real-time transcript endpoint,
+ * validates incoming messages with Zod, and auto-reconnects on failure.
  */
 
+import WebSocket from 'ws';
+import { z } from 'zod';
 import type { TranscriptSegment } from './models.js';
 
 export type OnSegmentCallback = (segment: TranscriptSegment) => Promise<void>;
 
+// ---------------------------------------------------------------------------
+// Zod schema for incoming Skribby messages
+// ---------------------------------------------------------------------------
+
+const SkribbyMessageSchema = z.object({
+  text: z.string(),
+  speaker: z.string().nullable().default(null),
+  timestamp: z.number(),
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BASE_URL = 'wss://api.skribby.io/v1/bots';
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1_000;
+const CLEAN_CLOSE_CODE = 1000;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Open a WebSocket to Skribby and stream transcript segments to the callback.
+ *
+ * - Validates every incoming message with Zod before forwarding.
+ * - Auto-reconnects with exponential backoff (1 s, 2 s, 4 s) up to 3 retries.
+ * - Resolves when the connection closes cleanly (code 1000 -- meeting ended).
+ * - Rejects only when retries are exhausted after unexpected disconnects.
+ */
 export async function streamTranscript(
-  _botId: string,
-  _apiKey: string,
-  _onSegment: OnSegmentCallback,
+  botId: string,
+  apiKey: string,
+  onSegment: OnSegmentCallback,
 ): Promise<void> {
-  // TODO: Issue #2 — implement WebSocket client with auto-reconnect
-  throw new Error('Not implemented — see Issue #2');
+  let retries = 0;
+
+  const connect = (): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+      const url = `${BASE_URL}/${botId}/transcript`;
+
+      const ws = new WebSocket(url, {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+
+      ws.on('message', (raw: WebSocket.RawData) => {
+        handleMessage(raw, onSegment);
+      });
+
+      ws.on('close', (code: number) => {
+        if (code === CLEAN_CLOSE_CODE) {
+          resolve();
+          return;
+        }
+
+        // Unexpected close -- attempt reconnect
+        if (retries < MAX_RETRIES) {
+          const delay = INITIAL_BACKOFF_MS * Math.pow(2, retries);
+          retries += 1;
+          setTimeout(() => {
+            connect().then(resolve, reject);
+          }, delay);
+        } else {
+          reject(new Error(`WebSocket closed unexpectedly (code ${code}) after ${MAX_RETRIES} retries`));
+        }
+      });
+
+      ws.on('error', () => {
+        // The 'close' event always fires after 'error', so reconnect logic
+        // is handled there. Swallow the error to prevent unhandled rejection.
+      });
+    });
+
+  return connect();
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function handleMessage(raw: WebSocket.RawData, onSegment: OnSegmentCallback): void {
+  try {
+    const parsed: unknown = JSON.parse(String(raw));
+    const segment = SkribbyMessageSchema.parse(parsed);
+    onSegment(segment).catch((err: unknown) => {
+      console.error('onSegment callback error:', err instanceof Error ? err.message : err);
+    });
+  } catch (err: unknown) {
+    console.error(
+      'Failed to parse transcript message:',
+      err instanceof Error ? err.message : err,
+    );
+  }
 }


### PR DESCRIPTION
## Summary

Implements Issue #2 — live transcript streaming from Skribby WebSocket.

- **listen.ts**: WebSocket client connecting to `wss://api.skribby.io/v1/bots/{botId}/transcript`
- Auth via Bearer token in headers
- Validates incoming messages with Zod schema before passing to callback
- Auto-reconnect with exponential backoff (1s/2s/4s, max 3 retries)
- Clean close (code 1000 = meeting ended) resolves without reconnect
- Callback errors caught and logged — never crash the stream
- Malformed/invalid messages logged and skipped

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx eslint src/` — zero lint errors
- [x] `npx vitest run` — 118/118 tests passing (10 new)
- [x] Connection URL and auth headers
- [x] Message parsing → TranscriptSegment callback
- [x] Malformed JSON resilience
- [x] Reconnect on unexpected close
- [x] Clean close without reconnect
- [x] Callback error isolation

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)