### PR TITLE
feat: ElevenLabs TTS voice output (#5)

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -9,7 +9,7 @@ import { streamTranscript } from './listen.js';
 import { extractIntents } from './detect.js';
 import { isDuplicate } from './dedup.js';
 import { routeIntent } from './route.js';
-import { speak } from './speak.js';
+import { speakGreeting } from './speak.js';
 import { generateAndSendSummary } from './summary.js';
 
 const EXTRACTION_INTERVAL_MS = 30_000;
@@ -27,10 +27,7 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
     throw new Error('Cannot run pipeline: session has no botId (join step did not complete)');
   }
 
-  await speak(
-    `${config.instanceName} is here. I'll handle action items as we go.`,
-    config,
-  );
+  await speakGreeting(config, session.botId);
 
   let bufferText = '';
   let lastExtractionTime = Date.now();

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OpenClawConfig } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock functions — vi.hoisted() makes these available to vi.mock()
+// factories which are hoisted above all other code at transform time.
+// ---------------------------------------------------------------------------
+
+const { mockConvert, mockAxiosPost } = vi.hoisted(() => ({
+  mockConvert: vi.fn(),
+  mockAxiosPost: vi.fn(),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock ElevenLabs SDK
+// ---------------------------------------------------------------------------
+
+vi.mock('@elevenlabs/elevenlabs-js', () => {
+  return {
+    ElevenLabsClient: vi.fn().mockImplementation(() => ({
+      textToSpeech: { convert: mockConvert },
+    })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Mock axios
+// ---------------------------------------------------------------------------
+
+vi.mock('axios', () => {
+  return {
+    default: { post: mockAxiosPost },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import after mocks are in place
+// ---------------------------------------------------------------------------
+
+import { speak, speakGreeting } from './speak.js';
+import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const mockConfig: OpenClawConfig = {
+  instanceName: 'TestClaw',
+  skribbyApiKey: 'sk-skribby-test',
+  elevenLabsApiKey: 'sk-eleven-test',
+  anthropicApiKey: 'sk-ant-test',
+  githubToken: null,
+  githubRepo: null,
+  telegramBotToken: null,
+  telegramChatId: null,
+  confidenceThreshold: 0.85,
+};
+
+const BOT_ID = 'bot-123';
+
+/**
+ * Build a minimal ReadableStream<Uint8Array> that yields `data` then closes.
+ */
+function fakeAudioStream(data: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(data);
+      controller.close();
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('speak', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAxiosPost.mockResolvedValue({ status: 200 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Happy path
+  // -------------------------------------------------------------------------
+
+  it('generates TTS audio and posts it to Skribby', async () => {
+    const audioBytes = new Uint8Array([0x49, 0x44, 0x33]); // fake MP3 header
+    mockConvert.mockResolvedValueOnce(fakeAudioStream(audioBytes));
+
+    await speak('Hello meeting', mockConfig, BOT_ID);
+
+    // ElevenLabs client constructed with API key
+    expect(ElevenLabsClient).toHaveBeenCalledWith({
+      apiKey: 'sk-eleven-test',
+    });
+
+    // TTS convert called with correct voice + model
+    expect(mockConvert).toHaveBeenCalledOnce();
+    expect(mockConvert).toHaveBeenCalledWith(
+      '21m00Tcm4TlvDq8ikWAM',
+      expect.objectContaining({
+        text: 'Hello meeting',
+        modelId: 'eleven_turbo_v2_5',
+        outputFormat: 'mp3_44100_128',
+      }),
+    );
+
+    // Audio buffer posted to Skribby speak endpoint
+    expect(mockAxiosPost).toHaveBeenCalledOnce();
+    const [url, body, opts] = mockAxiosPost.mock.calls[0];
+    expect(url).toBe('https://api.skribby.io/v1/bots/bot-123/speak');
+    expect(Buffer.isBuffer(body)).toBe(true);
+    expect(opts.headers['Authorization']).toBe('Bearer sk-skribby-test');
+    expect(opts.headers['Content-Type']).toBe('audio/mpeg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Empty text
+  // -------------------------------------------------------------------------
+
+  it('skips without API call when text is empty', async () => {
+    await speak('', mockConfig, BOT_ID);
+
+    expect(mockConvert).not.toHaveBeenCalled();
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('skips without API call when text is whitespace-only', async () => {
+    await speak('   \n\t  ', mockConfig, BOT_ID);
+
+    expect(mockConvert).not.toHaveBeenCalled();
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Silent degradation: ElevenLabs failure
+  // -------------------------------------------------------------------------
+
+  it('does not throw when ElevenLabs API fails', async () => {
+    mockConvert.mockRejectedValueOnce(new Error('ElevenLabs rate limit'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(speak('Hello', mockConfig, BOT_ID)).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ElevenLabs rate limit'),
+    );
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Silent degradation: Skribby failure
+  // -------------------------------------------------------------------------
+
+  it('does not throw when Skribby audio POST fails', async () => {
+    const audioBytes = new Uint8Array([0xff, 0xfb]);
+    mockConvert.mockResolvedValueOnce(fakeAudioStream(audioBytes));
+    mockAxiosPost.mockRejectedValueOnce(new Error('Skribby 503'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(speak('Hello', mockConfig, BOT_ID)).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Skribby 503'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Silent degradation: non-Error thrown
+  // -------------------------------------------------------------------------
+
+  it('handles non-Error thrown values gracefully', async () => {
+    mockConvert.mockRejectedValueOnce('string error');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(speak('Hello', mockConfig, BOT_ID)).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown error'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  // -------------------------------------------------------------------------
+  // Long text warning
+  // -------------------------------------------------------------------------
+
+  it('logs a warning when text exceeds 200 characters', async () => {
+    const longText = 'A'.repeat(250);
+    mockConvert.mockResolvedValueOnce(fakeAudioStream(new Uint8Array([0x00])));
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await speak(longText, mockConfig, BOT_ID);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('250 chars'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('does not warn when text is within 200 characters', async () => {
+    const shortText = 'A'.repeat(100);
+    mockConvert.mockResolvedValueOnce(fakeAudioStream(new Uint8Array([0x00])));
+
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await speak(shortText, mockConfig, BOT_ID);
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// speakGreeting
+// ---------------------------------------------------------------------------
+
+describe('speakGreeting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAxiosPost.mockResolvedValue({ status: 200 });
+  });
+
+  it('speaks a greeting that includes the instance name', async () => {
+    mockConvert.mockResolvedValueOnce(
+      fakeAudioStream(new Uint8Array([0x00])),
+    );
+
+    await speakGreeting(mockConfig, BOT_ID);
+
+    expect(mockConvert).toHaveBeenCalledOnce();
+    const callArgs = mockConvert.mock.calls[0][1];
+    expect(callArgs.text).toContain('TestClaw');
+    expect(callArgs.text).toContain('action items');
+  });
+
+  it('does not throw when underlying speak fails', async () => {
+    mockConvert.mockRejectedValueOnce(new Error('network down'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(speakGreeting(mockConfig, BOT_ID)).resolves.toBeUndefined();
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -1,16 +1,111 @@
 /**
  * ElevenLabs TTS + Skribby audio injection.
- * Issue #5 — Smokefarmer.
- * Stub — full implementation in feature/issue-5-elevenlabs-tts branch.
+ * Issue #5 — Generates speech from text via ElevenLabs and sends the audio
+ * buffer to the Skribby bot so the meeting participants hear confirmations.
+ *
+ * CRITICAL: Every public function in this module MUST silently degrade on
+ * failure.  The meeting pipeline must never crash because TTS failed.
  */
 
+import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
+import axios from 'axios';
 import type { OpenClawConfig } from './config.js';
 
+/** Default voice — "Rachel", a clear female narration voice. */
+const DEFAULT_VOICE_ID = '21m00Tcm4TlvDq8ikWAM';
+
+/** Model optimised for lowest latency. */
+const TTS_MODEL_ID = 'eleven_turbo_v2_5';
+
+/** Output format suitable for Skribby playback. */
+const OUTPUT_FORMAT = 'mp3_44100_128' as const;
+
+/** Warn if text exceeds this character count. */
+const MAX_TEXT_LENGTH = 200;
+
+const SKRIBBY_BASE_URL = 'https://api.skribby.io/v1';
+
+/**
+ * Collect a web-standard `ReadableStream<Uint8Array>` into a single `Buffer`.
+ */
+async function collectStream(stream: ReadableStream<Uint8Array>): Promise<Buffer> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Generate TTS audio via ElevenLabs and POST it to Skribby so the meeting
+ * participants hear the bot speak.
+ *
+ * **Never throws** — all errors are caught and logged.
+ */
 export async function speak(
-  _text: string,
-  _config: OpenClawConfig,
+  text: string,
+  config: OpenClawConfig,
+  botId: string,
 ): Promise<void> {
-  // TODO: Issue #5 — ElevenLabs TTS → Skribby audio output
-  // Silent degradation: never throw, always catch
-  console.warn('speak() not implemented — see Issue #5');
+  try {
+    if (!text.trim()) {
+      return;
+    }
+
+    if (text.length > MAX_TEXT_LENGTH) {
+      console.warn(
+        `speak(): text is ${text.length} chars (>${MAX_TEXT_LENGTH}). ` +
+          'Consider shortening for faster TTS.',
+      );
+    }
+
+    const client = new ElevenLabsClient({ apiKey: config.elevenLabsApiKey });
+
+    const audioStream: ReadableStream<Uint8Array> = await client.textToSpeech.convert(
+      DEFAULT_VOICE_ID,
+      {
+        text,
+        modelId: TTS_MODEL_ID,
+        outputFormat: OUTPUT_FORMAT,
+      },
+    );
+
+    const audioBuffer = await collectStream(audioStream);
+
+    await axios.post(
+      `${SKRIBBY_BASE_URL}/bots/${botId}/speak`,
+      audioBuffer,
+      {
+        headers: {
+          Authorization: `Bearer ${config.skribbyApiKey}`,
+          'Content-Type': 'audio/mpeg',
+        },
+        maxBodyLength: Infinity,
+      },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`speak() failed (silent degradation): ${message}`);
+  }
+}
+
+/**
+ * Speak the standard greeting when the bot joins a meeting.
+ *
+ * **Never throws** — delegates to {@link speak} which handles all errors.
+ */
+export async function speakGreeting(
+  config: OpenClawConfig,
+  botId: string,
+): Promise<void> {
+  await speak(
+    `${config.instanceName} is here. I'll handle action items as we go.`,
+    config,
+    botId,
+  );
 }


### PR DESCRIPTION
## Summary

Implements Issue #5 — speak action confirmations into the meeting via ElevenLabs TTS.

- **speak.ts**: ElevenLabs TTS → Skribby bot audio injection
  - `speak(text, config, botId)` — generate + deliver voice, **never throws**
  - `speakGreeting(config, botId)` — standard greeting with instance name
  - Uses `eleven_turbo_v2_5` model (fastest, ≤3s latency target)
  - Silent degradation on any failure (ElevenLabs or Skribby)
  - Warns on text > 200 chars, skips empty text
- **pipeline.ts**: Updated to pass `botId` to speak functions

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx eslint src/` — zero lint errors
- [x] `npx vitest run` — 118/118 tests passing (10 new)
- [x] Happy path: TTS + Skribby delivery
- [x] Empty text → skip
- [x] ElevenLabs failure → silent degradation
- [x] Skribby POST failure → silent degradation
- [x] Long text warning
- [x] speakGreeting uses instance name
- [x] speakGreeting never throws on failure

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)