### PR TITLE
fix(converse): execute create_issue and schedule_followup actions from Q&A

### DIFF
--- a/src/converse.test.ts
+++ b/src/converse.test.ts
@@ -38,6 +38,19 @@ vi.mock('./speak.js', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Mock route module
+// ---------------------------------------------------------------------------
+
+const mockRouteIntent = vi.fn();
+
+vi.mock('./route.js', () => {
+  return {
+    routeIntent: (...args: unknown[]) => mockRouteIntent(...args),
+  };
+});
+
+
+// ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 
@@ -721,3 +734,134 @@ describe('buildMeetingContext', () => {
     expect(context).toContain('Recent transcript:');
   });
 });
+
+
+// ---------------------------------------------------------------------------
+// handleAddressedSpeech — action execution
+// ---------------------------------------------------------------------------
+
+describe('handleAddressedSpeech — action execution', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+    mockSpeak.mockReset();
+    mockRouteIntent.mockReset();
+    mockSpeak.mockResolvedValue(undefined);
+    mockRouteIntent.mockResolvedValue(undefined);
+  });
+
+  it('calls routeIntent with BUG intent when action is create_issue', async () => {
+    const config = makeConfig();
+    const session = makeSession(config);
+    const responseJson = JSON.stringify({
+      answer: "I'll create that issue for you.",
+      action: 'create_issue',
+      actionDetail: 'Login page broken on mobile',
+    });
+    mockCreate.mockResolvedValueOnce(makeAnthropicResponse(responseJson));
+
+    await handleAddressedSpeech('create an issue for the login bug', session, config);
+
+    // Wait for fire-and-forget to settle
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRouteIntent).toHaveBeenCalledOnce();
+    const [intent] = mockRouteIntent.mock.calls[0] as [{ type: string; text: string; confidence: number }];
+    expect(intent.type).toBe('BUG');
+    expect(intent.text).toBe('Login page broken on mobile');
+    expect(intent.confidence).toBe(1.0);
+  });
+
+  it('calls routeIntent with MEETING_REQUEST intent when action is schedule_followup', async () => {
+    const config = makeConfig();
+    const session = makeSession(config);
+    const responseJson = JSON.stringify({
+      answer: "I'll schedule that follow-up.",
+      action: 'schedule_followup',
+      actionDetail: 'Team sync next Tuesday at 10am',
+    });
+    mockCreate.mockResolvedValueOnce(makeAnthropicResponse(responseJson));
+
+    await handleAddressedSpeech('schedule a follow-up for next Tuesday', session, config);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRouteIntent).toHaveBeenCalledOnce();
+    const [intent] = mockRouteIntent.mock.calls[0] as [{ type: string; text: string }];
+    expect(intent.type).toBe('MEETING_REQUEST');
+    expect(intent.text).toBe('Team sync next Tuesday at 10am');
+  });
+
+  it('does not call routeIntent when action is none', async () => {
+    const config = makeConfig();
+    const session = makeSession(config);
+    const responseJson = JSON.stringify({
+      answer: 'Three decisions were made.',
+      action: 'none',
+      actionDetail: null,
+    });
+    mockCreate.mockResolvedValueOnce(makeAnthropicResponse(responseJson));
+
+    await handleAddressedSpeech('what decisions were made?', session, config);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRouteIntent).not.toHaveBeenCalled();
+  });
+
+  it('does not call routeIntent when actionDetail is null even if action is set', async () => {
+    const config = makeConfig();
+    const session = makeSession(config);
+    const responseJson = JSON.stringify({
+      answer: 'Sure.',
+      action: 'create_issue',
+      actionDetail: null,
+    });
+    mockCreate.mockResolvedValueOnce(makeAnthropicResponse(responseJson));
+
+    await handleAddressedSpeech('create issue', session, config);
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockRouteIntent).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when routeIntent rejects for create_issue', async () => {
+    const config = makeConfig();
+    const session = makeSession(config);
+    const responseJson = JSON.stringify({
+      answer: "I'll try to create that issue.",
+      action: 'create_issue',
+      actionDetail: 'Some bug',
+    });
+    mockCreate.mockResolvedValueOnce(makeAnthropicResponse(responseJson));
+    mockRouteIntent.mockRejectedValueOnce(new Error('GitHub rate limit'));
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      handleAddressedSpeech('create an issue', session, config),
+    ).resolves.toBeUndefined();
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    consoleSpy.mockRestore();
+  });
+
+  it('still speaks the answer even when routeIntent fails', async () => {
+    const config = makeConfig();
+    const session = makeSession(config);
+    const responseJson = JSON.stringify({
+      answer: 'Creating that issue now.',
+      action: 'create_issue',
+      actionDetail: 'Critical crash on startup',
+    });
+    mockCreate.mockResolvedValueOnce(makeAnthropicResponse(responseJson));
+    mockRouteIntent.mockRejectedValueOnce(new Error('GitHub offline'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await handleAddressedSpeech('log the startup crash', session, config);
+
+    expect(mockSpeak).toHaveBeenCalledOnce();
+    expect(mockSpeak).toHaveBeenCalledWith('Creating that issue now.', config, 'bot-123');
+  });
+});
+

--- a/src/converse.ts
+++ b/src/converse.ts
@@ -4,6 +4,9 @@
  *
  * Detects wake-word in transcript segments, routes addressed speech to Claude
  * for a conversational response using meeting context, and speaks the answer.
+ *
+ * Actions returned by Claude (create_issue, schedule_followup) are now
+ * executed automatically via the intent router.
  */
 
 import Anthropic from '@anthropic-ai/sdk';
@@ -13,6 +16,8 @@ import type { MeetingSession } from './session.js';
 import type { OpenClawConfig } from './config.js';
 import { speak } from './speak.js';
 import { CONVERSATION_SYSTEM_PROMPT, buildMeetingContext } from './prompts.js';
+import { routeIntent } from './route.js';
+import { randomUUID } from 'crypto';
 
 const HAIKU_MODEL = 'claude-3-haiku-20240307';
 const MAX_TOKENS = 512;
@@ -116,7 +121,59 @@ export function parseConversationResponse(text: string): ConversationResponse {
 }
 
 /**
- * Handle an addressed segment: generate response and speak it.
+ * Execute a conversation action returned by Claude.
+ * Converts create_issue → BUG intent, schedule_followup → MEETING_REQUEST intent.
+ * Never throws — errors are logged and the meeting continues.
+ */
+async function executeConversationAction(
+  response: ConversationResponse,
+  session: MeetingSession,
+  config: OpenClawConfig,
+): Promise<void> {
+  if (response.action === 'none' || !response.actionDetail) return;
+
+  if (response.action === 'create_issue') {
+    const intent = {
+      id: randomUUID(),
+      type: 'BUG' as const,
+      text: response.actionDetail,
+      owner: null,
+      deadline: null,
+      priority: 'medium' as const,
+      confidence: 1.0, // User explicitly requested — skip threshold check
+      sourceQuote: response.actionDetail,
+    };
+    try {
+      await routeIntent(intent, session, config);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      console.error('converse: create_issue action failed:', message);
+    }
+    return;
+  }
+
+  if (response.action === 'schedule_followup') {
+    const intent = {
+      id: randomUUID(),
+      type: 'MEETING_REQUEST' as const,
+      text: response.actionDetail,
+      owner: null,
+      deadline: null,
+      priority: 'medium' as const,
+      confidence: 1.0,
+      sourceQuote: response.actionDetail,
+    };
+    try {
+      await routeIntent(intent, session, config);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      console.error('converse: schedule_followup action failed:', message);
+    }
+  }
+}
+
+/**
+ * Handle an addressed segment: generate response, speak it, and execute any action.
  * Never throws — errors are logged and the meeting continues.
  */
 export async function handleAddressedSpeech(
@@ -135,6 +192,12 @@ export async function handleAddressedSpeech(
       : response.answer;
 
     await speak(spokenAnswer, config, session.botId);
+
+    // Execute any action Claude decided on (fire-and-forget, errors logged internally)
+    executeConversationAction(response, session, config).catch((err) => {
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      console.error('converse: action execution error:', message);
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error('Q&A response failed:', message);


### PR DESCRIPTION
## Summary

Implements the follow-up flagged by @NostraAI in the PR #16 review:

> `action: 'create_issue' | 'schedule_followup'` is detected but not yet acted on in the pipeline — it's just returned in the response.

## Changes

### `converse.ts`
- Added `executeConversationAction()` — maps Claude's action response to actual intent routing:
  - `create_issue` → BUG intent with `confidence: 1.0` (user explicitly requested, skips threshold)
  - `schedule_followup` → MEETING_REQUEST intent with `confidence: 1.0`
- `handleAddressedSpeech()` now fire-and-forgets `executeConversationAction()` after speaking — errors logged, never throws
- `randomUUID()` used for intent IDs (Node built-in, no new dep)

### `converse.test.ts`
- Added `mockRouteIntent` mock for `./route.js`
- Added 6 new tests in `handleAddressedSpeech — action execution`:
  - `create_issue` → `routeIntent` called with BUG intent + confidence 1.0 ✓
  - `schedule_followup` → `routeIntent` called with MEETING_REQUEST intent ✓
  - `action: none` → `routeIntent` not called ✓
  - `actionDetail: null` → `routeIntent` not called ✓
  - `routeIntent` rejection → does not throw ✓
  - `routeIntent` failure → answer still spoken ✓

## Test count
202 existing + 6 new = 208 tests