### PR TITLE
fix: correct Skribby API base URL and endpoint paths

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -6,19 +6,15 @@
 import axios from 'axios';
 import { z } from 'zod';
 
-const SKRIBBY_API_BASE = 'https://api.skribby.io/v1';
+const SKRIBBY_API_BASE = 'https://platform.skribby.io/api/v1';
 
 /**
  * Zod schema for Skribby API response.
- * Skribby returns snake_case (bot_id) — we transform to camelCase.
+ * Skribby returns an id field for the bot.
  */
 const SkribbyJoinResponseSchema = z.object({
-  bot_id: z.string().min(1),
+  id: z.string().min(1),
 });
-
-export interface JoinResult {
-  botId: string;
-}
 
 export async function joinMeeting(
   meetingUrl: string,
@@ -26,10 +22,12 @@ export async function joinMeeting(
   apiKey: string,
 ): Promise<string> {
   const response = await axios.post(
-    `${SKRIBBY_API_BASE}/bots`,
+    `${SKRIBBY_API_BASE}/bot`,
     {
       meeting_url: meetingUrl,
-      bot_display_name: botName,
+      bot_name: botName,
+      service: 'gmeet',
+      transcription_model: 'openai/whisper-large-v3',
     },
     {
       headers: {
@@ -41,5 +39,5 @@ export async function joinMeeting(
   );
 
   const parsed = SkribbyJoinResponseSchema.parse(response.data);
-  return parsed.bot_id;
+  return parsed.id;
 }

--- a/src/listen.test.ts
+++ b/src/listen.test.ts
@@ -71,7 +71,7 @@ describe('streamTranscript', () => {
     streamTranscript('bot-123', 'sk-test-key', onSegment);
 
     const ws = latestWs();
-    expect(ws.url).toBe('wss://api.skribby.io/v1/bots/bot-123/transcript');
+    expect(ws.url).toBe('wss://platform.skribby.io/api/v1/bot/bot-123/transcript');
     expect(ws.options).toEqual(
       expect.objectContaining({
         headers: { Authorization: 'Bearer sk-test-key' },

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -24,7 +24,7 @@ const SkribbyMessageSchema = z.object({
 // Constants
 // ---------------------------------------------------------------------------
 
-const BASE_URL = 'wss://api.skribby.io/v1/bots';
+const BASE_URL = 'wss://platform.skribby.io/api/v1/bot';
 const MAX_RETRIES = 3;
 const INITIAL_BACKOFF_MS = 1_000;
 const CLEAN_CLOSE_CODE = 1000;

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -109,7 +109,7 @@ describe('speak', () => {
     // Audio buffer posted to Skribby speak endpoint
     expect(mockAxiosPost).toHaveBeenCalledOnce();
     const [url, body, opts] = mockAxiosPost.mock.calls[0];
-    expect(url).toBe('https://api.skribby.io/v1/bots/bot-123/speak');
+    expect(url).toBe('https://platform.skribby.io/api/v1/bot/bot-123/speak');
     expect(Buffer.isBuffer(body)).toBe(true);
     expect(opts.headers['Authorization']).toBe('Bearer sk-skribby-test');
     expect(opts.headers['Content-Type']).toBe('audio/mpeg');

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -23,7 +23,7 @@ const OUTPUT_FORMAT = 'mp3_44100_128' as const;
 /** Warn if text exceeds this character count. */
 const MAX_TEXT_LENGTH = 200;
 
-const SKRIBBY_BASE_URL = 'https://api.skribby.io/v1';
+const SKRIBBY_BASE_URL = 'https://platform.skribby.io/api/v1';
 
 /**
  * Collect a web-standard `ReadableStream<Uint8Array>` into a single `Buffer`.
@@ -78,7 +78,7 @@ export async function speak(
     const audioBuffer = await collectStream(audioStream);
 
     await axios.post(
-      `${SKRIBBY_BASE_URL}/bots/${botId}/speak`,
+      `${SKRIBBY_BASE_URL}/bot/${botId}/speak`,
       audioBuffer,
       {
         headers: {


### PR DESCRIPTION
## Bug Fix

The Skribby API base URL was wrong — `api.skribby.io` doesn't exist. Real base URL is `platform.skribby.io/api/v1`.

Also fixed:
- `POST /bots` → `POST /bot` (correct endpoint)
- Added required fields: `service: 'gmeet'`, `transcription_model: 'openai/whisper-large-v3'`
- Bot ID response field: `bot_id` → `id`
- `/bots/{id}/speak` → `/bot/{id}/speak`
- WebSocket: `wss://api.skribby.io/v1/bots` → `wss://platform.skribby.io/api/v1/bot`

## Testing
216/216 passing