### PR TITLE
fix: Skribby dynamic websocket_url + ElevenLabs free tier voice

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -1,6 +1,6 @@
 /**
  * Skribby API: create bot and join a Google Meet call.
- * Issue #1 — implementation shared between NostraAI (gateway) and Smokefarmer (join logic).
+ * Returns bot ID and WebSocket URL for real-time transcript streaming.
  */
 
 import axios from 'axios';
@@ -9,25 +9,31 @@ import { z } from 'zod';
 const SKRIBBY_API_BASE = 'https://platform.skribby.io/api/v1';
 
 /**
- * Zod schema for Skribby API response.
- * Skribby returns an id field for the bot.
+ * Zod schema for Skribby API bot creation response.
  */
 const SkribbyJoinResponseSchema = z.object({
   id: z.string().min(1),
+  websocket_url: z.string().url().optional(),
+  websocket_read_only_url: z.string().url().optional(),
 });
+
+export interface JoinResult {
+  botId: string;
+  websocketUrl: string | null;
+}
 
 export async function joinMeeting(
   meetingUrl: string,
   botName: string,
   apiKey: string,
-): Promise<string> {
+): Promise<JoinResult> {
   const response = await axios.post(
     `${SKRIBBY_API_BASE}/bot`,
     {
       meeting_url: meetingUrl,
       bot_name: botName,
       service: 'gmeet',
-      transcription_model: 'openai/whisper-large-v3',
+      transcription_model: 'openai/whisper-large-v3-realtime',
     },
     {
       headers: {
@@ -39,5 +45,8 @@ export async function joinMeeting(
   );
 
   const parsed = SkribbyJoinResponseSchema.parse(response.data);
-  return parsed.id;
+  return {
+    botId: parsed.id,
+    websocketUrl: parsed.websocket_url ?? parsed.websocket_read_only_url ?? null,
+  };
 }

--- a/src/listen.test.ts
+++ b/src/listen.test.ts
@@ -45,7 +45,7 @@ function latestWs(): MockWebSocket {
 }
 
 function sendMessage(ws: MockWebSocket, data: unknown): void {
-  ws.emit('message', Buffer.from(JSON.stringify(data)));
+  ws.emit("message", Buffer.from(JSON.stringify({ type: "transcript", data: { ...data, is_final: true } })));
 }
 
 // ---------------------------------------------------------------------------
@@ -68,7 +68,7 @@ describe('streamTranscript', () => {
 
   it('connects with correct URL and authorization header', () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    streamTranscript('bot-123', 'sk-test-key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-123/transcript', 'sk-test-key', onSegment);
 
     const ws = latestWs();
     expect(ws.url).toBe('wss://platform.skribby.io/api/v1/bot/bot-123/transcript');
@@ -85,7 +85,7 @@ describe('streamTranscript', () => {
 
   it('parses incoming message and calls onSegment with TranscriptSegment', async () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
-    streamTranscript('bot-1', 'key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     const message = { text: 'Hello world', speaker: 'Alice', timestamp: 1000 };
@@ -105,7 +105,7 @@ describe('streamTranscript', () => {
 
   it('defaults speaker to null when missing from message', async () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
-    streamTranscript('bot-1', 'key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     sendMessage(ws, { text: 'No speaker', timestamp: 2000 });
@@ -124,7 +124,7 @@ describe('streamTranscript', () => {
     const onSegment = vi.fn<OnSegmentCallback>();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    streamTranscript('bot-1', 'key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
     const ws = latestWs();
 
     // Send invalid JSON
@@ -145,7 +145,7 @@ describe('streamTranscript', () => {
     const onSegment = vi.fn<OnSegmentCallback>();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    streamTranscript('bot-1', 'key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
     const ws = latestWs();
 
     // Missing required 'text' field
@@ -165,7 +165,7 @@ describe('streamTranscript', () => {
 
   it('resolves on clean close (code 1000) without reconnecting', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    const promise = streamTranscript('bot-1', 'key', onSegment);
+    const promise = streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     ws.emit('close', 1000);
@@ -180,7 +180,7 @@ describe('streamTranscript', () => {
 
   it('reconnects with exponential backoff on unexpected close (up to 3 times)', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    const promise = streamTranscript('bot-1', 'key', onSegment);
+    const promise = streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     // First connection -- unexpected close
     expect(instances).toHaveLength(1);
@@ -214,7 +214,7 @@ describe('streamTranscript', () => {
 
   it('reconnects then resolves if subsequent connection closes cleanly', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    const promise = streamTranscript('bot-1', 'key', onSegment);
+    const promise = streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     // First connection -- unexpected close
     latestWs().emit('close', 1006);
@@ -237,7 +237,7 @@ describe('streamTranscript', () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockRejectedValue(new Error('callback boom'));
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    streamTranscript('bot-1', 'key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
     const ws = latestWs();
 
     sendMessage(ws, { text: 'test', speaker: null, timestamp: 500 });
@@ -261,7 +261,7 @@ describe('streamTranscript', () => {
 
   it('swallows WebSocket error events without crashing', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    streamTranscript('bot-1', 'key', onSegment);
+    streamTranscript('wss://platform.skribby.io/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
 

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -1,7 +1,7 @@
 /**
  * Skribby WebSocket: receive live transcript stream.
- * Issue #2 -- connects to Skribby's real-time transcript endpoint,
- * validates incoming messages with Zod, and auto-reconnects on failure.
+ * Connects to the websocket_url returned by Skribby bot creation response.
+ * Handles Skribby's event envelope: { type: "transcript", data: { ... } }
  */
 
 import WebSocket from 'ws';
@@ -11,20 +11,27 @@ import type { TranscriptSegment } from './models.js';
 export type OnSegmentCallback = (segment: TranscriptSegment) => Promise<void>;
 
 // ---------------------------------------------------------------------------
-// Zod schema for incoming Skribby messages
+// Zod schemas for Skribby WebSocket events
 // ---------------------------------------------------------------------------
 
-const SkribbyMessageSchema = z.object({
+// Skribby wraps all events in { type, data }
+const SkribbyEventSchema = z.object({
+  type: z.string(),
+  data: z.unknown(),
+});
+
+// Transcript event data
+const SkribbyTranscriptDataSchema = z.object({
   text: z.string(),
-  speaker: z.string().nullable().default(null),
-  timestamp: z.number(),
+  speaker: z.string().nullable().optional().default(null),
+  timestamp: z.number().optional(),
+  is_final: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-const BASE_URL = 'wss://platform.skribby.io/api/v1/bot';
 const MAX_RETRIES = 3;
 const INITIAL_BACKOFF_MS = 1_000;
 const CLEAN_CLOSE_CODE = 1000;
@@ -35,14 +42,15 @@ const CLEAN_CLOSE_CODE = 1000;
 
 /**
  * Open a WebSocket to Skribby and stream transcript segments to the callback.
+ * Uses the websocketUrl returned from joinMeeting() — not a hardcoded URL.
  *
  * - Validates every incoming message with Zod before forwarding.
- * - Auto-reconnects with exponential backoff (1 s, 2 s, 4 s) up to 3 retries.
- * - Resolves when the connection closes cleanly (code 1000 -- meeting ended).
+ * - Auto-reconnects with exponential backoff (1s, 2s, 4s) up to 3 retries.
+ * - Resolves when the connection closes cleanly (code 1000 — meeting ended).
  * - Rejects only when retries are exhausted after unexpected disconnects.
  */
 export async function streamTranscript(
-  botId: string,
+  websocketUrl: string,
   apiKey: string,
   onSegment: OnSegmentCallback,
 ): Promise<void> {
@@ -50,9 +58,7 @@ export async function streamTranscript(
 
   const connect = (): Promise<void> =>
     new Promise<void>((resolve, reject) => {
-      const url = `${BASE_URL}/${botId}/transcript`;
-
-      const ws = new WebSocket(url, {
+      const ws = new WebSocket(websocketUrl, {
         headers: { Authorization: `Bearer ${apiKey}` },
       });
 
@@ -65,8 +71,6 @@ export async function streamTranscript(
           resolve();
           return;
         }
-
-        // Unexpected close -- attempt reconnect
         if (retries < MAX_RETRIES) {
           const delay = INITIAL_BACKOFF_MS * Math.pow(2, retries);
           retries += 1;
@@ -79,8 +83,7 @@ export async function streamTranscript(
       });
 
       ws.on('error', () => {
-        // The 'close' event always fires after 'error', so reconnect logic
-        // is handled there. Swallow the error to prevent unhandled rejection.
+        // close event always fires after error — reconnect handled there
       });
     });
 
@@ -94,14 +97,26 @@ export async function streamTranscript(
 function handleMessage(raw: WebSocket.RawData, onSegment: OnSegmentCallback): void {
   try {
     const parsed: unknown = JSON.parse(String(raw));
-    const segment = SkribbyMessageSchema.parse(parsed);
+    const event = SkribbyEventSchema.parse(parsed);
+
+    // Only process transcript events
+    if (event.type !== 'transcript') return;
+
+    const transcriptData = SkribbyTranscriptDataSchema.parse(event.data);
+
+    // Only forward final segments to avoid duplicates from partial transcripts
+    if (transcriptData.is_final === false) return;
+
+    const segment: TranscriptSegment = {
+      text: transcriptData.text,
+      speaker: transcriptData.speaker ?? null,
+      timestamp: transcriptData.timestamp ?? Date.now(),
+    };
+
     onSegment(segment).catch((err: unknown) => {
       console.error('onSegment callback error:', err instanceof Error ? err.message : err);
     });
   } catch (err: unknown) {
-    console.error(
-      'Failed to parse transcript message:',
-      err instanceof Error ? err.message : err,
-    );
+    console.error('Failed to parse transcript message:', err instanceof Error ? err.message : err);
   }
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -23,6 +23,9 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
   if (!session.botId) {
     throw new Error('Cannot run pipeline: session has no botId (join step did not complete)');
   }
+  if (!session.websocketUrl) {
+    throw new Error('Cannot run pipeline: session has no websocketUrl (join step did not return WebSocket URL — ensure a realtime transcription model is used)');
+  }
 
   await speakGreeting(config, session.botId);
 
@@ -64,7 +67,7 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
   };
 
   try {
-    await streamTranscript(session.botId, config.skribbyApiKey, onSegment);
+    await streamTranscript(session.websocketUrl, config.skribbyApiKey, onSegment);
   } finally {
     session.end();
     try {

--- a/src/session.ts
+++ b/src/session.ts
@@ -13,6 +13,7 @@ export class MeetingSession {
   readonly config: OpenClawConfig;
 
   botId: string | null = null;
+  websocketUrl: string | null = null;
   transcriptBuffer: TranscriptSegment[] = [];
   intents: Intent[] = [];
   createdIssues: CreatedIssue[] = [];

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -29,7 +29,9 @@ export async function handleMessage(
   await replyFn('Joining the call now...');
 
   try {
-    session.botId = await joinMeeting(meetUrl, config.instanceName, config.skribbyApiKey);
+    const joinResult = await joinMeeting(meetUrl, config.instanceName, config.skribbyApiKey);
+    session.botId = joinResult.botId;
+    session.websocketUrl = joinResult.websocketUrl;
     await replyFn(`✅ ${config.instanceName} has joined the meeting.`);
   } catch (err) {
     const errorMsg = safeErrorMessage(err);

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -98,7 +98,7 @@ describe('speak', () => {
     // TTS convert called with correct voice + model
     expect(mockConvert).toHaveBeenCalledOnce();
     expect(mockConvert).toHaveBeenCalledWith(
-      '21m00Tcm4TlvDq8ikWAM',
+      'pNInz6obpgDQGcFmaJgB',
       expect.objectContaining({
         text: 'Hello meeting',
         modelId: 'eleven_turbo_v2_5',

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -11,8 +11,8 @@ import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 import axios from 'axios';
 import type { OpenClawConfig } from './config.js';
 
-/** Default voice — "Rachel", a clear female narration voice. */
-const DEFAULT_VOICE_ID = '21m00Tcm4TlvDq8ikWAM';
+/** Default voice — "Adam", available on ElevenLabs free tier. */
+const DEFAULT_VOICE_ID = 'pNInz6obpgDQGcFmaJgB';
 
 /** Model optimised for lowest latency. */
 const TTS_MODEL_ID = 'eleven_turbo_v2_5';


### PR DESCRIPTION
## Fixes

Two issues found during live test:

### 1. Skribby WebSocket URL
- WebSocket URL is returned dynamically in bot creation response as `websocket_url` — not a fixed endpoint
- `join.ts`: now uses `openai/whisper-large-v3-realtime` model (required for real-time WebSocket) + returns `JoinResult { botId, websocketUrl }`
- `session.ts`: added `websocketUrl` field
- `skill.ts`: stores `websocketUrl` on session after join
- `listen.ts`: `streamTranscript(websocketUrl, apiKey, onSegment)` — takes full URL instead of botId
- `listen.ts`: handles Skribby's event envelope `{ type: 'transcript', data: { ... } }`
- `pipeline.ts`: passes `session.websocketUrl` to `streamTranscript`

### 2. ElevenLabs voice
- 'Rachel' (21m00...) requires paid plan
- Switched to 'Adam' (pNInz6obpgDQGcFmaJgB) — available on free tier

## Testing
216/216 passing