### PR TITLE
fix: use deepgram/nova-2-realtime transcription model

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -33,7 +33,7 @@ export async function joinMeeting(
       meeting_url: meetingUrl,
       bot_name: botName,
       service: 'gmeet',
-      transcription_model: 'openai/whisper-large-v3-realtime',
+      transcription_model: 'deepgram/nova-2-realtime',
     },
     {
       headers: {


### PR DESCRIPTION
openai/whisper-large-v3-realtime doesn't exist — 422 error. Correct realtime model is deepgram/nova-2-realtime. 216/216 tests.