### PR TITLE
feat: bot responds via Google Meet chat message (#26)

### DIFF
--- a/src/__tests__/route.test.ts
+++ b/src/__tests__/route.test.ts
@@ -8,9 +8,9 @@ import type { Intent } from '../models.js';
 import type { OpenClawConfig } from '../config.js';
 
 // Hoist mock functions so they're initialized before vi.mock factories run
-const { mockCreate, mockSpeak, mockIsDuplicate } = vi.hoisted(() => ({
+const { mockCreate, mockRespond, mockIsDuplicate } = vi.hoisted(() => ({
   mockCreate: vi.fn(),
-  mockSpeak: vi.fn(),
+  mockRespond: vi.fn(),
   mockIsDuplicate: vi.fn(),
 }));
 
@@ -29,7 +29,7 @@ vi.mock('../dedup.js', () => ({
 }));
 
 vi.mock('../speak.js', () => ({
-  speak: mockSpeak,
+  respond: mockRespond,
 }));
 
 // Import after mocks
@@ -40,7 +40,7 @@ const mockConfig: OpenClawConfig = {
   instanceName: 'test-bot',
   skribbyApiKey: 'test-skribby',
   elevenLabsApiKey: 'test-eleven',
-  anthropicApiKey: 'test-anthropic',
+  geminiApiKey: 'test-gemini',
   githubToken: 'ghp_test123',
   githubRepo: 'owner/repo',
   telegramBotToken: null,
@@ -68,7 +68,7 @@ describe('routeIntent', () => {
     session = new MeetingSession('https://meet.google.com/abc', mockConfig);
     session.botId = 'bot-123';
     mockIsDuplicate.mockReturnValue(false);
-    mockSpeak.mockResolvedValue(undefined);
+    mockRespond.mockResolvedValue(undefined);
     mockCreate.mockResolvedValue({
       data: {
         html_url: 'https://github.com/owner/repo/issues/42',
@@ -92,7 +92,7 @@ describe('routeIntent', () => {
       expect(mockIsDuplicate).toHaveBeenCalledWith(intent, session);
       expect(session.intents).toHaveLength(0);
       expect(mockCreate).not.toHaveBeenCalled();
-      expect(mockSpeak).not.toHaveBeenCalled();
+      expect(mockRespond).not.toHaveBeenCalled();
     });
 
     it('should add non-duplicate intent to session', async () => {
@@ -111,7 +111,7 @@ describe('routeIntent', () => {
 
       await routeIntent(intent, session, configNoToken);
 
-      expect(mockSpeak).toHaveBeenCalledWith(
+      expect(mockRespond).toHaveBeenCalledWith(
         "I don't have GitHub connected. I noted it locally.",
         configNoToken,
         'bot-123',
@@ -125,7 +125,7 @@ describe('routeIntent', () => {
 
       await routeIntent(intent, session, configNoRepo);
 
-      expect(mockSpeak).toHaveBeenCalledWith(
+      expect(mockRespond).toHaveBeenCalledWith(
         "I don't have GitHub connected. I noted it locally.",
         configNoRepo,
         'bot-123',
@@ -140,7 +140,7 @@ describe('routeIntent', () => {
 
       await routeIntent(intent, session, mockConfig);
 
-      expect(mockSpeak).toHaveBeenCalledWith(
+      expect(mockRespond).toHaveBeenCalledWith(
         expect.stringContaining('confidence'),
         mockConfig,
         'bot-123',
@@ -223,7 +223,7 @@ describe('routeIntent', () => {
 
       await routeIntent(intent, session, mockConfig);
 
-      expect(mockSpeak).toHaveBeenCalledWith(
+      expect(mockRespond).toHaveBeenCalledWith(
         expect.stringContaining('#42'),
         mockConfig,
         'bot-123',
@@ -291,7 +291,7 @@ describe('routeIntent', () => {
 
       await routeIntent(intent, session, mockConfig);
 
-      expect(mockSpeak).toHaveBeenCalledWith(
+      expect(mockRespond).toHaveBeenCalledWith(
         expect.stringContaining('failed'),
         mockConfig,
         'bot-123',
@@ -371,10 +371,10 @@ describe('routeIntent', () => {
     });
   });
 
-  describe('speak is fire-and-forget', () => {
-    it('should not await speak calls (fire-and-forget)', async () => {
-      // speak is mocked to return a Promise that rejects
-      mockSpeak.mockRejectedValue(new Error('TTS failed'));
+  describe('respond is fire-and-forget', () => {
+    it('should not await respond calls (fire-and-forget)', async () => {
+      // respond is mocked to return a Promise that rejects
+      mockRespond.mockRejectedValue(new Error('TTS failed'));
       const intent = createIntent();
 
       // This should not throw even though speak rejects

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,7 +10,6 @@ import type { OpenClawConfig } from './config.js';
 function setRequiredEnvVars(): void {
   process.env.OPENCLAW_INSTANCE_NAME = 'test-bot';
   process.env.SKRIBBY_API_KEY = 'sk-skribby-test';
-  process.env.ELEVENLABS_API_KEY = 'sk-eleven-test';
   process.env.GEMINI_API_KEY = 'gemini-test-key';
 }
 
@@ -44,6 +43,7 @@ describe('loadConfig', () => {
   describe('with all valid env vars', () => {
     it('returns a config object with correct values', () => {
       setRequiredEnvVars();
+      process.env.ELEVENLABS_API_KEY = 'sk-eleven-test';
       process.env.GITHUB_TOKEN = 'ghp-test-token';
       process.env.GITHUB_REPO = 'org/repo';
       process.env.TELEGRAM_BOT_TOKEN = 'tg-bot-test';
@@ -81,12 +81,14 @@ describe('loadConfig', () => {
       expect(() => loadConfig()).toThrow(ZodError);
     });
 
-    it('throws ZodError when ELEVENLABS_API_KEY is missing', () => {
+    it('defaults elevenLabsApiKey to null when ELEVENLABS_API_KEY is missing', () => {
       process.env.OPENCLAW_INSTANCE_NAME = 'test-bot';
       process.env.SKRIBBY_API_KEY = 'sk-skribby-test';
       process.env.GEMINI_API_KEY = 'gemini-test-key';
 
-      expect(() => loadConfig()).toThrow(ZodError);
+      const config = loadConfig();
+
+      expect(config.elevenLabsApiKey).toBeNull();
     });
 
     it('throws ZodError when GEMINI_API_KEY is missing', () => {
@@ -111,7 +113,6 @@ describe('loadConfig', () => {
         const paths = zodErr.issues.map((issue) => issue.path[0]);
         expect(paths).toContain('instanceName');
         expect(paths).toContain('skribbyApiKey');
-        expect(paths).toContain('elevenLabsApiKey');
         expect(paths).toContain('geminiApiKey');
       }
     });
@@ -131,6 +132,7 @@ describe('loadConfig', () => {
 
       const config = loadConfig();
 
+      expect(config.elevenLabsApiKey).toBeNull();
       expect(config.githubToken).toBeNull();
       expect(config.githubRepo).toBeNull();
       expect(config.telegramBotToken).toBeNull();
@@ -139,6 +141,7 @@ describe('loadConfig', () => {
 
     it('defaults nullable fields to null when env vars are empty strings', () => {
       setRequiredEnvVars();
+      process.env.ELEVENLABS_API_KEY = '';
       process.env.GITHUB_TOKEN = '';
       process.env.GITHUB_REPO = '';
       process.env.TELEGRAM_BOT_TOKEN = '';
@@ -146,6 +149,7 @@ describe('loadConfig', () => {
 
       const config = loadConfig();
 
+      expect(config.elevenLabsApiKey).toBeNull();
       expect(config.githubToken).toBeNull();
       expect(config.githubRepo).toBeNull();
       expect(config.telegramBotToken).toBeNull();
@@ -189,7 +193,10 @@ describe('loadConfig', () => {
       expect(config).toBeDefined();
       expect(typeof config.instanceName).toBe('string');
       expect(typeof config.skribbyApiKey).toBe('string');
-      expect(typeof config.elevenLabsApiKey).toBe('string');
+      // elevenLabsApiKey is nullable — string when set, null otherwise
+      expect(
+        config.elevenLabsApiKey === null || typeof config.elevenLabsApiKey === 'string',
+      ).toBe(true);
       expect(typeof config.geminiApiKey).toBe('string');
       expect(typeof config.confidenceThreshold).toBe('number');
     });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 const ConfigSchema = z.object({
   instanceName: z.string().min(1).max(50).regex(/^[a-zA-Z0-9 _-]+$/),
   skribbyApiKey: z.string().min(1),
-  elevenLabsApiKey: z.string().min(1),
+  elevenLabsApiKey: z.string().nullable().default(null),
   geminiApiKey: z.string().min(1),
   githubToken: z.string().nullable().default(null),
   githubRepo: z.string().regex(/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/).nullable().default(null),
@@ -19,7 +19,7 @@ export function loadConfig(): OpenClawConfig {
   return ConfigSchema.parse({
     instanceName: process.env.OPENCLAW_INSTANCE_NAME ?? '',
     skribbyApiKey: process.env.SKRIBBY_API_KEY ?? '',
-    elevenLabsApiKey: process.env.ELEVENLABS_API_KEY ?? '',
+    elevenLabsApiKey: process.env.ELEVENLABS_API_KEY || null,
     geminiApiKey: process.env.GEMINI_API_KEY ?? '',
     githubToken: process.env.GITHUB_TOKEN || null,
     githubRepo: process.env.GITHUB_REPO || null,

--- a/src/converse.test.ts
+++ b/src/converse.test.ts
@@ -31,11 +31,11 @@ vi.mock('@google/generative-ai', () => {
 // Mock speak module
 // ---------------------------------------------------------------------------
 
-const mockSpeak = vi.fn();
+const mockRespond = vi.fn();
 
 vi.mock('./speak.js', () => {
   return {
-    speak: (...args: unknown[]) => mockSpeak(...args),
+    respond: (...args: unknown[]) => mockRespond(...args),
   };
 });
 
@@ -249,8 +249,8 @@ describe('parseConversationResponse', () => {
 describe('handleAddressedSpeech', () => {
   beforeEach(() => {
     mockGenerateContent.mockReset();
-    mockSpeak.mockReset();
-    mockSpeak.mockResolvedValue(undefined);
+    mockRespond.mockReset();
+    mockRespond.mockResolvedValue(undefined);
   });
 
   it('generates a response and calls speak with the answer', async () => {
@@ -264,8 +264,8 @@ describe('handleAddressedSpeech', () => {
     await handleAddressedSpeech('what was decided?', session, config);
 
     expect(mockGenerateContent).toHaveBeenCalledOnce();
-    expect(mockSpeak).toHaveBeenCalledOnce();
-    expect(mockSpeak).toHaveBeenCalledWith(
+    expect(mockRespond).toHaveBeenCalledOnce();
+    expect(mockRespond).toHaveBeenCalledWith(
       'We decided to use TypeScript.',
       config,
       'bot-123',
@@ -279,7 +279,7 @@ describe('handleAddressedSpeech', () => {
     await handleAddressedSpeech('', session, config);
 
     expect(mockGenerateContent).not.toHaveBeenCalled();
-    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(mockRespond).not.toHaveBeenCalled();
   });
 
   it('returns without calling API when question is whitespace only', async () => {
@@ -289,7 +289,7 @@ describe('handleAddressedSpeech', () => {
     await handleAddressedSpeech('   ', session, config);
 
     expect(mockGenerateContent).not.toHaveBeenCalled();
-    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(mockRespond).not.toHaveBeenCalled();
   });
 
   it('returns without calling API when session has no botId', async () => {
@@ -300,7 +300,7 @@ describe('handleAddressedSpeech', () => {
     await handleAddressedSpeech('what happened?', session, config);
 
     expect(mockGenerateContent).not.toHaveBeenCalled();
-    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(mockRespond).not.toHaveBeenCalled();
   });
 
   it('catches API errors and does not throw', async () => {
@@ -313,7 +313,7 @@ describe('handleAddressedSpeech', () => {
       handleAddressedSpeech('summarize', session, config),
     ).resolves.toBeUndefined();
 
-    expect(mockSpeak).not.toHaveBeenCalled();
+    expect(mockRespond).not.toHaveBeenCalled();
     expect(consoleSpy).toHaveBeenCalledWith(
       'Q&A response failed:',
       'API rate limited',
@@ -349,8 +349,8 @@ describe('handleAddressedSpeech', () => {
 
     await handleAddressedSpeech('give me details', session, config);
 
-    expect(mockSpeak).toHaveBeenCalledOnce();
-    const spokenText = mockSpeak.mock.calls[0][0] as string;
+    expect(mockRespond).toHaveBeenCalledOnce();
+    const spokenText = mockRespond.mock.calls[0][0] as string;
     // 200 - 3 for "..." + 3 for "..." = 200 total
     expect(spokenText.length).toBeLessThanOrEqual(200);
     expect(spokenText.endsWith('...')).toBe(true);
@@ -367,8 +367,8 @@ describe('handleAddressedSpeech', () => {
 
     await handleAddressedSpeech('short question', session, config);
 
-    expect(mockSpeak).toHaveBeenCalledOnce();
-    const spokenText = mockSpeak.mock.calls[0][0] as string;
+    expect(mockRespond).toHaveBeenCalledOnce();
+    const spokenText = mockRespond.mock.calls[0][0] as string;
     expect(spokenText).toBe(exactAnswer);
     expect(spokenText).not.toContain('...');
   });
@@ -380,7 +380,7 @@ describe('handleAddressedSpeech', () => {
       answer: 'Test answer.',
     });
     mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
-    mockSpeak.mockRejectedValueOnce(new Error('TTS failed'));
+    mockRespond.mockRejectedValueOnce(new Error('TTS failed'));
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(

--- a/src/converse.ts
+++ b/src/converse.ts
@@ -11,11 +11,10 @@ import { z } from 'zod';
 import type { TranscriptSegment } from './models.js';
 import type { MeetingSession } from './session.js';
 import type { OpenClawConfig } from './config.js';
-import { speak } from './speak.js';
+import { respond } from './speak.js';
 import { CONVERSATION_SYSTEM_PROMPT, buildMeetingContext } from './prompts.js';
 
 const GEMINI_MODEL = 'gemini-2.0-flash';
-const MAX_TOKENS = 512;
 const MAX_RESPONSE_LENGTH = 200;
 const QA_COOLDOWN_MS = 5_000;
 const QA_MAX_PER_SESSION = 30;
@@ -137,7 +136,7 @@ export async function handleAddressedSpeech(
       ? response.answer.slice(0, MAX_RESPONSE_LENGTH - 3) + '...'
       : response.answer;
 
-    await speak(spokenAnswer, config, session.botId);
+    await respond(spokenAnswer, config, session.botId);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error('Q&A response failed:', message);

--- a/src/route.ts
+++ b/src/route.ts
@@ -11,7 +11,7 @@ import type { Intent, CreatedIssue } from './models.js';
 import type { MeetingSession } from './session.js';
 import type { OpenClawConfig } from './config.js';
 import { isDuplicate } from './dedup.js';
-import { speak } from './speak.js';
+import { respond } from './speak.js';
 
 /**
  * Route an intent to the appropriate action handler.
@@ -49,7 +49,7 @@ async function handleGitHubIntent(
   // Check GitHub configuration
   if (!config.githubToken || !config.githubRepo) {
     if (session.botId) {
-      speak("I don't have GitHub connected. I noted it locally.", config, session.botId).catch(console.error);
+      respond("I don't have GitHub connected. I noted it locally.", config, session.botId).catch(console.error);
     }
     return;
   }
@@ -57,7 +57,7 @@ async function handleGitHubIntent(
   // Check confidence threshold
   if (intent.confidence < config.confidenceThreshold) {
     if (session.botId) {
-      speak(`I detected a ${intent.type.toLowerCase()} but my confidence is low. Please confirm: "${intent.text}"`, config, session.botId).catch(console.error);
+      respond(`I detected a ${intent.type.toLowerCase()} but my confidence is low. Please confirm: "${intent.text}"`, config, session.botId).catch(console.error);
     }
     return;
   }
@@ -66,13 +66,13 @@ async function handleGitHubIntent(
     const issue = await createGitHubIssue(intent, session, config);
     session.addCreatedIssue(issue);
     if (session.botId) {
-      speak(`Created GitHub issue #${issue.issueNumber}: ${issue.title}`, config, session.botId).catch(console.error);
+      respond(`Created GitHub issue #${issue.issueNumber}: ${issue.title}`, config, session.botId).catch(console.error);
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : 'Unknown error';
     console.error('GitHub issue creation failed:', errMsg);
     if (session.botId) {
-      speak('GitHub issue creation failed. I\'ll include this in the meeting summary instead.', config, session.botId).catch(console.error);
+      respond('GitHub issue creation failed. I\'ll include this in the meeting summary instead.', config, session.botId).catch(console.error);
     }
   }
 }

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -37,23 +37,30 @@ vi.mock('axios', () => {
 // Import after mocks are in place
 // ---------------------------------------------------------------------------
 
-import { speak, speakGreeting } from './speak.js';
+import { respond, sendChatMessage, speakGreeting } from './speak.js';
 import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-const mockConfig: OpenClawConfig = {
+/** Config with ElevenLabs enabled (chat + TTS). */
+const mockConfigWithTTS: OpenClawConfig = {
   instanceName: 'TestClaw',
   skribbyApiKey: 'sk-skribby-test',
   elevenLabsApiKey: 'sk-eleven-test',
-  anthropicApiKey: 'sk-ant-test',
+  geminiApiKey: 'gemini-test-key',
   githubToken: null,
   githubRepo: null,
   telegramBotToken: null,
   telegramChatId: null,
   confidenceThreshold: 0.85,
+};
+
+/** Config without ElevenLabs (chat only, no TTS). */
+const mockConfigChatOnly: OpenClawConfig = {
+  ...mockConfigWithTTS,
+  elevenLabsApiKey: null,
 };
 
 const BOT_ID = 'bot-123';
@@ -71,24 +78,93 @@ function fakeAudioStream(data: Uint8Array): ReadableStream<Uint8Array> {
 }
 
 // ---------------------------------------------------------------------------
-// Tests
+// sendChatMessage
 // ---------------------------------------------------------------------------
 
-describe('speak', () => {
+describe('sendChatMessage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAxiosPost.mockResolvedValue({ status: 200 });
+  });
+
+  it('posts text to Skribby chat-message endpoint', async () => {
+    await sendChatMessage('Hello meeting', mockConfigWithTTS, BOT_ID);
+
+    expect(mockAxiosPost).toHaveBeenCalledOnce();
+    const [url, body, opts] = mockAxiosPost.mock.calls[0];
+    expect(url).toBe('https://platform.skribby.io/api/v1/bot/bot-123/chat-message');
+    expect(body).toEqual({ message: 'Hello meeting' });
+    expect(opts.headers['Authorization']).toBe('Bearer sk-skribby-test');
+    expect(opts.headers['Content-Type']).toBe('application/json');
+  });
+
+  it('skips when text is empty', async () => {
+    await sendChatMessage('', mockConfigWithTTS, BOT_ID);
+
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('skips when text is whitespace-only', async () => {
+    await sendChatMessage('   \n\t  ', mockConfigWithTTS, BOT_ID);
+
+    expect(mockAxiosPost).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when Skribby chat API fails (silent degradation)', async () => {
+    mockAxiosPost.mockRejectedValueOnce(new Error('Skribby 503'));
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('sendChatMessage() failed'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+
+  it('handles non-Error thrown values gracefully', async () => {
+    mockAxiosPost.mockRejectedValueOnce('string error');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Unknown error'),
+    );
+
+    consoleSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// respond
+// ---------------------------------------------------------------------------
+
+describe('respond', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAxiosPost.mockResolvedValue({ status: 200 });
   });
 
   // -------------------------------------------------------------------------
-  // Happy path
+  // Chat + TTS (elevenLabsApiKey set)
   // -------------------------------------------------------------------------
 
-  it('generates TTS audio and posts it to Skribby', async () => {
+  it('sends chat message and TTS audio when elevenLabsApiKey is set', async () => {
     const audioBytes = new Uint8Array([0x49, 0x44, 0x33]); // fake MP3 header
     mockConvert.mockResolvedValueOnce(fakeAudioStream(audioBytes));
 
-    await speak('Hello meeting', mockConfig, BOT_ID);
+    await respond('Hello meeting', mockConfigWithTTS, BOT_ID);
+
+    // Chat message sent first
+    const chatCall = mockAxiosPost.mock.calls.find(
+      (call) => (call[0] as string).includes('chat-message'),
+    );
+    expect(chatCall).toBeDefined();
+    expect(chatCall![1]).toEqual({ message: 'Hello meeting' });
 
     // ElevenLabs client constructed with API key
     expect(ElevenLabsClient).toHaveBeenCalledWith({
@@ -107,30 +183,47 @@ describe('speak', () => {
     );
 
     // Audio buffer posted to Skribby speak endpoint
+    const speakCall = mockAxiosPost.mock.calls.find(
+      (call) => (call[0] as string).includes('/speak'),
+    );
+    expect(speakCall).toBeDefined();
+    expect(Buffer.isBuffer(speakCall![1])).toBe(true);
+    expect(speakCall![2].headers['Content-Type']).toBe('audio/mpeg');
+  });
+
+  // -------------------------------------------------------------------------
+  // Chat only (elevenLabsApiKey null)
+  // -------------------------------------------------------------------------
+
+  it('sends chat message but skips TTS when elevenLabsApiKey is null', async () => {
+    await respond('Hello meeting', mockConfigChatOnly, BOT_ID);
+
+    // Chat message sent
     expect(mockAxiosPost).toHaveBeenCalledOnce();
-    const [url, body, opts] = mockAxiosPost.mock.calls[0];
-    expect(url).toBe('https://platform.skribby.io/api/v1/bot/bot-123/speak');
-    expect(Buffer.isBuffer(body)).toBe(true);
-    expect(opts.headers['Authorization']).toBe('Bearer sk-skribby-test');
-    expect(opts.headers['Content-Type']).toBe('audio/mpeg');
+    const [url] = mockAxiosPost.mock.calls[0];
+    expect(url).toContain('chat-message');
+
+    // No TTS
+    expect(mockConvert).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
   // Empty text
   // -------------------------------------------------------------------------
 
-  it('skips without API call when text is empty', async () => {
-    await speak('', mockConfig, BOT_ID);
+  it('skips both chat and TTS when text is empty', async () => {
+    await respond('', mockConfigWithTTS, BOT_ID);
 
-    expect(mockConvert).not.toHaveBeenCalled();
+    // sendChatMessage returns early for empty text
     expect(mockAxiosPost).not.toHaveBeenCalled();
+    expect(mockConvert).not.toHaveBeenCalled();
   });
 
-  it('skips without API call when text is whitespace-only', async () => {
-    await speak('   \n\t  ', mockConfig, BOT_ID);
+  it('skips both chat and TTS when text is whitespace-only', async () => {
+    await respond('   \n\t  ', mockConfigWithTTS, BOT_ID);
 
-    expect(mockConvert).not.toHaveBeenCalled();
     expect(mockAxiosPost).not.toHaveBeenCalled();
+    expect(mockConvert).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------------
@@ -142,28 +235,30 @@ describe('speak', () => {
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(speak('Hello', mockConfig, BOT_ID)).resolves.toBeUndefined();
+    await expect(respond('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('ElevenLabs rate limit'),
     );
-    expect(mockAxiosPost).not.toHaveBeenCalled();
 
     consoleSpy.mockRestore();
   });
 
   // -------------------------------------------------------------------------
-  // Silent degradation: Skribby failure
+  // Silent degradation: Skribby TTS upload failure
   // -------------------------------------------------------------------------
 
   it('does not throw when Skribby audio POST fails', async () => {
     const audioBytes = new Uint8Array([0xff, 0xfb]);
     mockConvert.mockResolvedValueOnce(fakeAudioStream(audioBytes));
-    mockAxiosPost.mockRejectedValueOnce(new Error('Skribby 503'));
+    // First call (chat-message) succeeds, second call (speak) fails
+    mockAxiosPost
+      .mockResolvedValueOnce({ status: 200 })
+      .mockRejectedValueOnce(new Error('Skribby 503'));
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(speak('Hello', mockConfig, BOT_ID)).resolves.toBeUndefined();
+    await expect(respond('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('Skribby 503'),
@@ -173,15 +268,15 @@ describe('speak', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Silent degradation: non-Error thrown
+  // Silent degradation: non-Error thrown in TTS
   // -------------------------------------------------------------------------
 
-  it('handles non-Error thrown values gracefully', async () => {
+  it('handles non-Error thrown values gracefully in TTS path', async () => {
     mockConvert.mockRejectedValueOnce('string error');
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(speak('Hello', mockConfig, BOT_ID)).resolves.toBeUndefined();
+    await expect(respond('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('Unknown error'),
@@ -191,14 +286,14 @@ describe('speak', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Long text warning
+  // Long text truncation (TTS path)
   // -------------------------------------------------------------------------
 
-  it('silently truncates text exceeding 200 characters', async () => {
+  it('silently truncates text exceeding 200 characters for TTS', async () => {
     const longText = 'A'.repeat(250);
     mockConvert.mockResolvedValueOnce(fakeAudioStream(new Uint8Array([0x00])));
 
-    await speak(longText, mockConfig, BOT_ID);
+    await respond(longText, mockConfigWithTTS, BOT_ID);
 
     expect(mockConvert).toHaveBeenCalledOnce();
     const callArgs = mockConvert.mock.calls[0][1];
@@ -206,11 +301,11 @@ describe('speak', () => {
     expect(callArgs.text).toBe('A'.repeat(200));
   });
 
-  it('does not truncate text within 200 characters', async () => {
+  it('does not truncate text within 200 characters for TTS', async () => {
     const shortText = 'A'.repeat(100);
     mockConvert.mockResolvedValueOnce(fakeAudioStream(new Uint8Array([0x00])));
 
-    await speak(shortText, mockConfig, BOT_ID);
+    await respond(shortText, mockConfigWithTTS, BOT_ID);
 
     expect(mockConvert).toHaveBeenCalledOnce();
     const callArgs = mockConvert.mock.calls[0][1];
@@ -229,25 +324,46 @@ describe('speakGreeting', () => {
     mockAxiosPost.mockResolvedValue({ status: 200 });
   });
 
-  it('speaks a greeting that includes the instance name', async () => {
+  it('sends a greeting via respond that includes the instance name', async () => {
     mockConvert.mockResolvedValueOnce(
       fakeAudioStream(new Uint8Array([0x00])),
     );
 
-    await speakGreeting(mockConfig, BOT_ID);
+    await speakGreeting(mockConfigWithTTS, BOT_ID);
 
+    // Chat message should include the instance name
+    const chatCall = mockAxiosPost.mock.calls.find(
+      (call) => (call[0] as string).includes('chat-message'),
+    );
+    expect(chatCall).toBeDefined();
+    expect((chatCall![1] as { message: string }).message).toContain('TestClaw');
+    expect((chatCall![1] as { message: string }).message).toContain('action items');
+
+    // TTS should also be called (elevenLabsApiKey is set)
     expect(mockConvert).toHaveBeenCalledOnce();
     const callArgs = mockConvert.mock.calls[0][1];
     expect(callArgs.text).toContain('TestClaw');
     expect(callArgs.text).toContain('action items');
   });
 
-  it('does not throw when underlying speak fails', async () => {
+  it('sends greeting via chat only when elevenLabsApiKey is null', async () => {
+    await speakGreeting(mockConfigChatOnly, BOT_ID);
+
+    // Chat message sent
+    expect(mockAxiosPost).toHaveBeenCalledOnce();
+    const [url] = mockAxiosPost.mock.calls[0];
+    expect(url).toContain('chat-message');
+
+    // No TTS
+    expect(mockConvert).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when underlying respond fails', async () => {
     mockConvert.mockRejectedValueOnce(new Error('network down'));
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(speakGreeting(mockConfig, BOT_ID)).resolves.toBeUndefined();
+    await expect(speakGreeting(mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
 
     consoleSpy.mockRestore();
   });

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -1,10 +1,11 @@
 /**
- * ElevenLabs TTS + Skribby audio injection.
- * Issue #5 — Generates speech from text via ElevenLabs and sends the audio
- * buffer to the Skribby bot so the meeting participants hear confirmations.
+ * Bot response delivery — Skribby chat message (primary) + ElevenLabs TTS (optional).
+ *
+ * sendChatMessage(): Posts text to Google Meet chat via Skribby — works on all plans.
+ * speak(): ElevenLabs TTS + Skribby audio injection — requires paid Skribby.
  *
  * CRITICAL: Every public function in this module MUST silently degrade on
- * failure.  The meeting pipeline must never crash because TTS failed.
+ * failure. The meeting pipeline must never crash because response delivery failed.
  */
 
 import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
@@ -20,10 +21,110 @@ const TTS_MODEL_ID = 'eleven_turbo_v2_5';
 /** Output format suitable for Skribby playback. */
 const OUTPUT_FORMAT = 'mp3_44100_128' as const;
 
-/** Warn if text exceeds this character count. */
+/** Max text length for TTS. */
 const MAX_TEXT_LENGTH = 200;
 
 const SKRIBBY_BASE_URL = 'https://platform.skribby.io/api/v1';
+
+/**
+ * Send a text message into the Google Meet chat via Skribby.
+ * Available on all Skribby plans (free included).
+ *
+ * **Never throws** — all errors are caught and logged.
+ */
+export async function sendChatMessage(
+  text: string,
+  config: OpenClawConfig,
+  botId: string,
+): Promise<void> {
+  try {
+    if (!text.trim()) return;
+
+    await axios.post(
+      `${SKRIBBY_BASE_URL}/bot/${botId}/chat-message`,
+      { message: text },
+      {
+        headers: {
+          Authorization: `Bearer ${config.skribbyApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        timeout: 10_000,
+      },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`sendChatMessage() failed (silent degradation): ${message}`);
+  }
+}
+
+/**
+ * Respond to the meeting — sends a chat message (always) and optionally speaks via TTS.
+ * Chat message is the primary delivery; TTS is best-effort on top.
+ *
+ * **Never throws** — all errors are caught and logged.
+ */
+export async function respond(
+  text: string,
+  config: OpenClawConfig,
+  botId: string,
+): Promise<void> {
+  // Always send chat message (works on free Skribby)
+  await sendChatMessage(text, config, botId);
+
+  // Optionally speak via TTS if ElevenLabs is configured and Skribby paid
+  if (config.elevenLabsApiKey) {
+    await speakTTS(text, config.elevenLabsApiKey, config.skribbyApiKey, botId);
+  }
+}
+
+/**
+ * Generate TTS audio via ElevenLabs and POST it to Skribby so the meeting
+ * participants hear the bot speak. Requires paid Skribby plan.
+ *
+ * **Never throws** — all errors are caught and logged.
+ */
+async function speakTTS(
+  text: string,
+  elevenLabsApiKey: string,
+  skribbyApiKey: string,
+  botId: string,
+): Promise<void> {
+  try {
+    if (!text.trim()) return;
+
+    const safeText = text.length > MAX_TEXT_LENGTH
+      ? text.slice(0, MAX_TEXT_LENGTH)
+      : text;
+
+    const client = new ElevenLabsClient({ apiKey: elevenLabsApiKey });
+
+    const audioStream: ReadableStream<Uint8Array> = await client.textToSpeech.convert(
+      DEFAULT_VOICE_ID,
+      {
+        text: safeText,
+        modelId: TTS_MODEL_ID,
+        outputFormat: OUTPUT_FORMAT,
+      },
+    );
+
+    const audioBuffer = await collectStream(audioStream);
+
+    await axios.post(
+      `${SKRIBBY_BASE_URL}/bot/${botId}/speak`,
+      audioBuffer,
+      {
+        headers: {
+          Authorization: `Bearer ${skribbyApiKey}`,
+          'Content-Type': 'audio/mpeg',
+        },
+        maxBodyLength: 5 * 1024 * 1024,
+      },
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    console.error(`speak() failed (silent degradation): ${message}`);
+  }
+}
 
 /**
  * Collect a web-standard `ReadableStream<Uint8Array>` into a single `Buffer`.
@@ -42,66 +143,16 @@ async function collectStream(stream: ReadableStream<Uint8Array>): Promise<Buffer
 }
 
 /**
- * Generate TTS audio via ElevenLabs and POST it to Skribby so the meeting
- * participants hear the bot speak.
+ * Send the standard greeting when the bot joins a meeting.
  *
- * **Never throws** — all errors are caught and logged.
- */
-export async function speak(
-  text: string,
-  config: OpenClawConfig,
-  botId: string,
-): Promise<void> {
-  try {
-    if (!text.trim()) {
-      return;
-    }
-
-    const safeText = text.length > MAX_TEXT_LENGTH
-      ? text.slice(0, MAX_TEXT_LENGTH)
-      : text;
-
-    const client = new ElevenLabsClient({ apiKey: config.elevenLabsApiKey });
-
-    const audioStream: ReadableStream<Uint8Array> = await client.textToSpeech.convert(
-      DEFAULT_VOICE_ID,
-      {
-        text: safeText,
-        modelId: TTS_MODEL_ID,
-        outputFormat: OUTPUT_FORMAT,
-      },
-    );
-
-    const audioBuffer = await collectStream(audioStream);
-
-    await axios.post(
-      `${SKRIBBY_BASE_URL}/bot/${botId}/speak`,
-      audioBuffer,
-      {
-        headers: {
-          Authorization: `Bearer ${config.skribbyApiKey}`,
-          'Content-Type': 'audio/mpeg',
-        },
-        maxBodyLength: 5 * 1024 * 1024,
-      },
-    );
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : 'Unknown error';
-    console.error(`speak() failed (silent degradation): ${message}`);
-  }
-}
-
-/**
- * Speak the standard greeting when the bot joins a meeting.
- *
- * **Never throws** — delegates to {@link speak} which handles all errors.
+ * **Never throws** — delegates to {@link respond}.
  */
 export async function speakGreeting(
   config: OpenClawConfig,
   botId: string,
 ): Promise<void> {
-  await speak(
-    `${config.instanceName} is here. I'll handle action items as we go.`,
+  await respond(
+    `👋 ${config.instanceName} is here. I'll handle action items as we go.`,
     config,
     botId,
   );


### PR DESCRIPTION
## Summary

Implements Issue #26 — bot responds in the Google Meet chat via Skribby's `POST /bot/{id}/chat-message` endpoint. Works on **all Skribby plans** (free included).

### New response model

| Function | What it does | Skribby plan |
|----------|-------------|-------------|
| `sendChatMessage()` | Posts text to Meet chat | Free |
| `speakTTS()` | ElevenLabs TTS → Skribby audio | Paid |
| `respond()` | Chat message (always) + TTS (if configured) | Free+ |

- `respond()` is now the single entry point for all bot responses
- Chat message is always sent — immediate, visible, reliable
- TTS voice is best-effort on top (only if `elevenLabsApiKey` is set)
- `elevenLabsApiKey` is now **optional** in config (nullable)

### Callers updated
- `route.ts`: all `speak()` → `respond()` (issue created, errors, confirmations)
- `converse.ts`: Q&A answers via `respond()`
- `pipeline.ts`: greeting via `speakGreeting()` → `respond()`

## Test plan
- [x] `npx tsc --noEmit` — zero type errors
- [x] `npx eslint src/` — zero lint errors
- [x] `npx vitest run` — **219/219 tests passing** (7 new)
- [x] sendChatMessage: success, empty skip, silent degradation
- [x] respond: chat+TTS path, chat-only path, error handling
- [x] speakGreeting: chat + optional TTS
- [x] Config: elevenLabsApiKey nullable, defaults to null

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)