### PR TITLE
feat: paid ElevenLabs voice + deepgram realtime transcription

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -33,7 +33,7 @@ export async function joinMeeting(
       meeting_url: meetingUrl,
       bot_name: botName,
       service: 'gmeet',
-      transcription_model: 'openai/whisper-large-v3',
+      transcription_model: 'deepgram/nova-2-realtime',
     },
     {
       headers: {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -24,7 +24,7 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
     throw new Error('Cannot run pipeline: session has no botId (join step did not complete)');
   }
   if (!session.websocketUrl) {
-    console.warn('No websocketUrl — real-time transcription unavailable (standard model). Bot is in the call but will not stream live transcript.');
+    console.warn('No websocketUrl — Skribby did not return a WebSocket URL. Check your plan supports deepgram/nova-2-realtime.');
   }
 
   await speakGreeting(config, session.botId);

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -174,7 +174,7 @@ describe('respond', () => {
     // TTS convert called with correct voice + model
     expect(mockConvert).toHaveBeenCalledOnce();
     expect(mockConvert).toHaveBeenCalledWith(
-      'pNInz6obpgDQGcFmaJgB',
+      'aOcS60CY8CoaVaZfqqb5',
       expect.objectContaining({
         text: 'Hello meeting',
         modelId: 'eleven_turbo_v2_5',

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -12,8 +12,8 @@ import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 import axios from 'axios';
 import type { OpenClawConfig } from './config.js';
 
-/** Default voice — "Adam", available on ElevenLabs free tier. */
-const DEFAULT_VOICE_ID = 'pNInz6obpgDQGcFmaJgB';
+/** Voice ID from ElevenLabs voice library (paid plan). */
+const DEFAULT_VOICE_ID = 'aOcS60CY8CoaVaZfqqb5';
 
 /** Model optimised for lowest latency. */
 const TTS_MODEL_ID = 'eleven_turbo_v2_5';


### PR DESCRIPTION
Paid plans now active:\n- ElevenLabs voice: `aOcS60CY8CoaVaZfqqb5` (from voice library)\n- Skribby: `deepgram/nova-2-realtime` — enables live WebSocket transcript stream\n\n219/219 tests.