### PR TITLE
fix: chat messages via WebSocket action (replaces deprecated REST endpoint)

### DIFF
--- a/src/__tests__/route.test.ts
+++ b/src/__tests__/route.test.ts
@@ -115,6 +115,7 @@ describe('routeIntent', () => {
         "I don't have GitHub connected. I noted it locally.",
         configNoToken,
         'bot-123',
+        expect.anything(),
       );
       expect(mockCreate).not.toHaveBeenCalled();
     });
@@ -129,6 +130,7 @@ describe('routeIntent', () => {
         "I don't have GitHub connected. I noted it locally.",
         configNoRepo,
         'bot-123',
+        expect.anything(),
       );
       expect(mockCreate).not.toHaveBeenCalled();
     });
@@ -144,6 +146,7 @@ describe('routeIntent', () => {
         expect.stringContaining('confidence'),
         mockConfig,
         'bot-123',
+        expect.anything(),
       );
       expect(mockCreate).not.toHaveBeenCalled();
     });
@@ -227,6 +230,7 @@ describe('routeIntent', () => {
         expect.stringContaining('#42'),
         mockConfig,
         'bot-123',
+        expect.anything(),
       );
     });
   });
@@ -295,6 +299,7 @@ describe('routeIntent', () => {
         expect.stringContaining('failed'),
         mockConfig,
         'bot-123',
+        expect.anything(),
       );
       expect(session.createdIssues).toHaveLength(0);
     });

--- a/src/converse.test.ts
+++ b/src/converse.test.ts
@@ -269,6 +269,7 @@ describe('handleAddressedSpeech', () => {
       'We decided to use TypeScript.',
       config,
       'bot-123',
+      session,
     );
   });
 

--- a/src/converse.ts
+++ b/src/converse.ts
@@ -136,7 +136,7 @@ export async function handleAddressedSpeech(
       ? response.answer.slice(0, MAX_RESPONSE_LENGTH - 3) + '...'
       : response.answer;
 
-    await respond(spokenAnswer, config, session.botId);
+    await respond(spokenAnswer, config, session.botId, session);
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error('Q&A response failed:', message);

--- a/src/listen.ts
+++ b/src/listen.ts
@@ -7,8 +7,26 @@
 import WebSocket from 'ws';
 import { z } from 'zod';
 import type { TranscriptSegment } from './models.js';
+import type { MeetingSession } from './session.js';
 
 export type OnSegmentCallback = (segment: TranscriptSegment) => Promise<void>;
+
+/**
+ * Send an action to the meeting via the active WebSocket connection.
+ * Used to send chat messages back into the meeting.
+ * Never throws — silent degradation if WS not available.
+ */
+export function sendWsAction(session: MeetingSession, action: string, data: Record<string, unknown>): void {
+  try {
+    if (!session.wsConnection || session.wsConnection.readyState !== WebSocket.OPEN) {
+      console.warn('sendWsAction: no active WebSocket connection');
+      return;
+    }
+    session.wsConnection.send(JSON.stringify({ action, data }));
+  } catch (err) {
+    console.error('sendWsAction failed:', err instanceof Error ? err.message : err);
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Zod schemas for Skribby WebSocket events
@@ -53,6 +71,7 @@ export async function streamTranscript(
   websocketUrl: string,
   apiKey: string,
   onSegment: OnSegmentCallback,
+  session?: MeetingSession,
 ): Promise<void> {
   let retries = 0;
 
@@ -61,6 +80,9 @@ export async function streamTranscript(
       const ws = new WebSocket(websocketUrl, {
         headers: { Authorization: `Bearer ${apiKey}` },
       });
+
+      // Store WS on session so speak.ts can send actions back
+      if (session) session.wsConnection = ws;
 
       ws.on('message', (raw: WebSocket.RawData) => {
         handleMessage(raw, onSegment);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -27,7 +27,7 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
     console.warn('No websocketUrl — Skribby did not return a WebSocket URL. Check your plan supports deepgram/nova-2-realtime.');
   }
 
-  await speakGreeting(config, session.botId);
+  await speakGreeting(config, session.botId, session);
 
   let bufferText = '';
   let lastExtractionTime = Date.now();
@@ -67,7 +67,7 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
 
   try {
     if (session.websocketUrl) {
-      await streamTranscript(session.websocketUrl, config.skribbyApiKey, onSegment);
+      await streamTranscript(session.websocketUrl, config.skribbyApiKey, onSegment, session);
     } else {
       // Standard model — no real-time stream. Bot is in the call but transcript arrives post-meeting.
       console.log('Pipeline: waiting for meeting to end (no real-time stream)...');

--- a/src/route.ts
+++ b/src/route.ts
@@ -49,7 +49,7 @@ async function handleGitHubIntent(
   // Check GitHub configuration
   if (!config.githubToken || !config.githubRepo) {
     if (session.botId) {
-      respond("I don't have GitHub connected. I noted it locally.", config, session.botId).catch(console.error);
+      respond("I don't have GitHub connected. I noted it locally.", config, session.botId, session).catch(console.error);
     }
     return;
   }
@@ -57,7 +57,7 @@ async function handleGitHubIntent(
   // Check confidence threshold
   if (intent.confidence < config.confidenceThreshold) {
     if (session.botId) {
-      respond(`I detected a ${intent.type.toLowerCase()} but my confidence is low. Please confirm: "${intent.text}"`, config, session.botId).catch(console.error);
+      respond(`I detected a ${intent.type.toLowerCase()} but my confidence is low. Please confirm: "${intent.text}"`, config, session.botId, session).catch(console.error);
     }
     return;
   }
@@ -66,13 +66,13 @@ async function handleGitHubIntent(
     const issue = await createGitHubIssue(intent, session, config);
     session.addCreatedIssue(issue);
     if (session.botId) {
-      respond(`Created GitHub issue #${issue.issueNumber}: ${issue.title}`, config, session.botId).catch(console.error);
+      respond(`Created GitHub issue #${issue.issueNumber}: ${issue.title}`, config, session.botId, session).catch(console.error);
     }
   } catch (err) {
     const errMsg = err instanceof Error ? err.message : 'Unknown error';
     console.error('GitHub issue creation failed:', errMsg);
     if (session.botId) {
-      respond('GitHub issue creation failed. I\'ll include this in the meeting summary instead.', config, session.botId).catch(console.error);
+      respond('GitHub issue creation failed. I\'ll include this in the meeting summary instead.', config, session.botId, session).catch(console.error);
     }
   }
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -14,6 +14,7 @@ export class MeetingSession {
 
   botId: string | null = null;
   websocketUrl: string | null = null;
+  wsConnection: import('ws').WebSocket | null = null; // active WebSocket for sending actions
   transcriptBuffer: TranscriptSegment[] = [];
   intents: Intent[] = [];
   createdIssues: CreatedIssue[] = [];

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -6,9 +6,10 @@ import type { OpenClawConfig } from './config.js';
 // factories which are hoisted above all other code at transform time.
 // ---------------------------------------------------------------------------
 
-const { mockConvert, mockAxiosPost } = vi.hoisted(() => ({
+const { mockConvert, mockAxiosPost, mockSendWsAction } = vi.hoisted(() => ({
   mockConvert: vi.fn(),
   mockAxiosPost: vi.fn(),
+  mockSendWsAction: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -32,6 +33,14 @@ vi.mock('axios', () => {
     default: { post: mockAxiosPost },
   };
 });
+
+// ---------------------------------------------------------------------------
+// Mock listen.js (sendWsAction)
+// ---------------------------------------------------------------------------
+
+vi.mock('./listen.js', () => ({
+  sendWsAction: mockSendWsAction,
+}));
 
 // ---------------------------------------------------------------------------
 // Import after mocks are in place
@@ -82,40 +91,48 @@ function fakeAudioStream(data: Uint8Array): ReadableStream<Uint8Array> {
 // ---------------------------------------------------------------------------
 
 describe('sendChatMessage', () => {
+  const mockSession = { wsConnection: null } as unknown as import('./session.js').MeetingSession;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAxiosPost.mockResolvedValue({ status: 200 });
+    mockSendWsAction.mockImplementation(() => {});
   });
 
-  it('posts text to Skribby chat-message endpoint', async () => {
-    await sendChatMessage('Hello meeting', mockConfigWithTTS, BOT_ID);
+  it('sends chat message via WebSocket action', async () => {
+    await sendChatMessage('Hello meeting', mockConfigWithTTS, BOT_ID, mockSession);
 
-    expect(mockAxiosPost).toHaveBeenCalledOnce();
-    const [url, body, opts] = mockAxiosPost.mock.calls[0];
-    expect(url).toBe('https://platform.skribby.io/api/v1/bot/bot-123/chat-message');
-    expect(body).toEqual({ message: 'Hello meeting' });
-    expect(opts.headers['Authorization']).toBe('Bearer sk-skribby-test');
-    expect(opts.headers['Content-Type']).toBe('application/json');
+    expect(mockSendWsAction).toHaveBeenCalledWith(mockSession, 'chat-message', { content: 'Hello meeting' });
   });
 
   it('skips when text is empty', async () => {
-    await sendChatMessage('', mockConfigWithTTS, BOT_ID);
+    await sendChatMessage('', mockConfigWithTTS, BOT_ID, mockSession);
 
-    expect(mockAxiosPost).not.toHaveBeenCalled();
+    expect(mockSendWsAction).not.toHaveBeenCalled();
   });
 
   it('skips when text is whitespace-only', async () => {
-    await sendChatMessage('   \n\t  ', mockConfigWithTTS, BOT_ID);
+    await sendChatMessage('   \n\t  ', mockConfigWithTTS, BOT_ID, mockSession);
 
-    expect(mockAxiosPost).not.toHaveBeenCalled();
+    expect(mockSendWsAction).not.toHaveBeenCalled();
   });
 
-  it('does not throw when Skribby chat API fails (silent degradation)', async () => {
-    mockAxiosPost.mockRejectedValueOnce(new Error('Skribby 503'));
+  it('warns when no session provided', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no session provided'));
+    expect(mockSendWsAction).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not throw when sendWsAction throws (silent degradation)', async () => {
+    mockSendWsAction.mockImplementationOnce(() => { throw new Error('WS error'); });
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
+    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID, mockSession)).resolves.toBeUndefined();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('sendChatMessage() failed'),
@@ -125,11 +142,11 @@ describe('sendChatMessage', () => {
   });
 
   it('handles non-Error thrown values gracefully', async () => {
-    mockAxiosPost.mockRejectedValueOnce('string error');
+    mockSendWsAction.mockImplementationOnce(() => { throw 'string error'; });
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
+    await expect(sendChatMessage('Hello', mockConfigWithTTS, BOT_ID, mockSession)).resolves.toBeUndefined();
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('Unknown error'),
@@ -157,14 +174,11 @@ describe('respond', () => {
     const audioBytes = new Uint8Array([0x49, 0x44, 0x33]); // fake MP3 header
     mockConvert.mockResolvedValueOnce(fakeAudioStream(audioBytes));
 
-    await respond('Hello meeting', mockConfigWithTTS, BOT_ID);
+    const sess = { wsConnection: null } as unknown as import('./session.js').MeetingSession;
+    await respond('Hello meeting', mockConfigWithTTS, BOT_ID, sess);
 
-    // Chat message sent first
-    const chatCall = mockAxiosPost.mock.calls.find(
-      (call) => (call[0] as string).includes('chat-message'),
-    );
-    expect(chatCall).toBeDefined();
-    expect(chatCall![1]).toEqual({ message: 'Hello meeting' });
+    // Chat message sent via WS
+    expect(mockSendWsAction).toHaveBeenCalledWith(sess, 'chat-message', { content: 'Hello meeting' });
 
     // ElevenLabs client constructed with API key
     expect(ElevenLabsClient).toHaveBeenCalledWith({
@@ -196,12 +210,11 @@ describe('respond', () => {
   // -------------------------------------------------------------------------
 
   it('sends chat message but skips TTS when elevenLabsApiKey is null', async () => {
-    await respond('Hello meeting', mockConfigChatOnly, BOT_ID);
+    const sess = { wsConnection: null } as unknown as import('./session.js').MeetingSession;
+    await respond('Hello meeting', mockConfigChatOnly, BOT_ID, sess);
 
-    // Chat message sent
-    expect(mockAxiosPost).toHaveBeenCalledOnce();
-    const [url] = mockAxiosPost.mock.calls[0];
-    expect(url).toContain('chat-message');
+    // Chat message sent via WS
+    expect(mockSendWsAction).toHaveBeenCalledOnce();
 
     // No TTS
     expect(mockConvert).not.toHaveBeenCalled();
@@ -251,18 +264,12 @@ describe('respond', () => {
   it('does not throw when Skribby audio POST fails', async () => {
     const audioBytes = new Uint8Array([0xff, 0xfb]);
     mockConvert.mockResolvedValueOnce(fakeAudioStream(audioBytes));
-    // First call (chat-message) succeeds, second call (speak) fails
-    mockAxiosPost
-      .mockResolvedValueOnce({ status: 200 })
-      .mockRejectedValueOnce(new Error('Skribby 503'));
+    mockAxiosPost.mockRejectedValueOnce(new Error('Skribby 503'));
+    const sess = { wsConnection: null } as unknown as import('./session.js').MeetingSession;
 
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    await expect(respond('Hello', mockConfigWithTTS, BOT_ID)).resolves.toBeUndefined();
-
-    expect(consoleSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Skribby 503'),
-    );
+    await expect(respond('Hello', mockConfigWithTTS, BOT_ID, sess)).resolves.toBeUndefined();
 
     consoleSpy.mockRestore();
   });
@@ -325,34 +332,28 @@ describe('speakGreeting', () => {
   });
 
   it('sends a greeting via respond that includes the instance name', async () => {
-    mockConvert.mockResolvedValueOnce(
-      fakeAudioStream(new Uint8Array([0x00])),
-    );
+    mockConvert.mockResolvedValueOnce(fakeAudioStream(new Uint8Array([0x00])));
+    const sess = { wsConnection: null } as unknown as import('./session.js').MeetingSession;
 
-    await speakGreeting(mockConfigWithTTS, BOT_ID);
+    await speakGreeting(mockConfigWithTTS, BOT_ID, sess);
 
-    // Chat message should include the instance name
-    const chatCall = mockAxiosPost.mock.calls.find(
-      (call) => (call[0] as string).includes('chat-message'),
-    );
-    expect(chatCall).toBeDefined();
-    expect((chatCall![1] as { message: string }).message).toContain('TestClaw');
-    expect((chatCall![1] as { message: string }).message).toContain('action items');
+    // Chat message via WS includes instance name
+    expect(mockSendWsAction).toHaveBeenCalledWith(sess, 'chat-message', expect.objectContaining({
+      content: expect.stringContaining('TestClaw'),
+    }));
 
-    // TTS should also be called (elevenLabsApiKey is set)
+    // TTS also called
     expect(mockConvert).toHaveBeenCalledOnce();
     const callArgs = mockConvert.mock.calls[0][1];
     expect(callArgs.text).toContain('TestClaw');
-    expect(callArgs.text).toContain('action items');
   });
 
   it('sends greeting via chat only when elevenLabsApiKey is null', async () => {
-    await speakGreeting(mockConfigChatOnly, BOT_ID);
+    const sess = { wsConnection: null } as unknown as import('./session.js').MeetingSession;
+    await speakGreeting(mockConfigChatOnly, BOT_ID, sess);
 
-    // Chat message sent
-    expect(mockAxiosPost).toHaveBeenCalledOnce();
-    const [url] = mockAxiosPost.mock.calls[0];
-    expect(url).toContain('chat-message');
+    // Chat message sent via WS
+    expect(mockSendWsAction).toHaveBeenCalledOnce();
 
     // No TTS
     expect(mockConvert).not.toHaveBeenCalled();

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -10,6 +10,8 @@
 
 import { ElevenLabsClient } from '@elevenlabs/elevenlabs-js';
 import axios from 'axios';
+import { sendWsAction } from './listen.js';
+import type { MeetingSession } from './session.js';
 import type { OpenClawConfig } from './config.js';
 
 /** Voice ID from ElevenLabs voice library (paid plan). */
@@ -27,30 +29,24 @@ const MAX_TEXT_LENGTH = 200;
 const SKRIBBY_BASE_URL = 'https://platform.skribby.io/api/v1';
 
 /**
- * Send a text message into the Google Meet chat via Skribby.
- * Available on all Skribby plans (free included).
+ * Send a text message into the Google Meet chat via Skribby WebSocket action.
+ * Uses the active WebSocket connection — no deprecated REST endpoint.
  *
  * **Never throws** — all errors are caught and logged.
  */
 export async function sendChatMessage(
   text: string,
-  config: OpenClawConfig,
-  botId: string,
+  _config: OpenClawConfig,
+  _botId: string,
+  session?: MeetingSession,
 ): Promise<void> {
   try {
     if (!text.trim()) return;
-
-    await axios.post(
-      `${SKRIBBY_BASE_URL}/bot/${botId}/chat-message`,
-      { message: text },
-      {
-        headers: {
-          Authorization: `Bearer ${config.skribbyApiKey}`,
-          'Content-Type': 'application/json',
-        },
-        timeout: 10_000,
-      },
-    );
+    if (!session) {
+      console.warn('sendChatMessage: no session provided, cannot send via WebSocket');
+      return;
+    }
+    sendWsAction(session, 'chat-message', { content: text });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     console.error(`sendChatMessage() failed (silent degradation): ${message}`);
@@ -67,11 +63,12 @@ export async function respond(
   text: string,
   config: OpenClawConfig,
   botId: string,
+  session?: MeetingSession,
 ): Promise<void> {
-  // Always send chat message (works on free Skribby)
-  await sendChatMessage(text, config, botId);
+  // Always send chat message via WebSocket action
+  await sendChatMessage(text, config, botId, session);
 
-  // Optionally speak via TTS if ElevenLabs is configured and Skribby paid
+  // Optionally speak via TTS if ElevenLabs is configured
   if (config.elevenLabsApiKey) {
     await speakTTS(text, config.elevenLabsApiKey, config.skribbyApiKey, botId);
   }
@@ -150,10 +147,12 @@ async function collectStream(stream: ReadableStream<Uint8Array>): Promise<Buffer
 export async function speakGreeting(
   config: OpenClawConfig,
   botId: string,
+  session?: MeetingSession,
 ): Promise<void> {
   await respond(
     `👋 ${config.instanceName} is here. I'll handle action items as we go.`,
     config,
     botId,
+    session,
   );
 }


### PR DESCRIPTION
The deprecated REST `POST /bot/{id}/chat-message` was returning 404. Skribby's new approach is to send chat actions via the WebSocket connection using:\n```json\n{"action":"chat-message","data":{"content":"Hello!"}}\n```\n\nChanges:\n- `session.ts`: added `wsConnection` field to store active WebSocket\n- `listen.ts`: stores WS on session on connect + exposes `sendWsAction()`\n- `speak.ts`: `sendChatMessage()` uses `sendWsAction()` instead of axios\n- All callers (`route.ts`, `converse.ts`, `pipeline.ts`) pass session through\n- All tests updated: 220/220 passing