### PR TITLE
fix: add automatic_audio_output to Recall.ai bot creation

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -30,6 +30,17 @@ export async function joinMeeting(
     {
       meeting_url: meetingUrl,
       bot_name: botName,
+      // Required to enable on-demand output_audio endpoint for ElevenLabs TTS injection
+      // See: https://docs.recall.ai/docs/output-audio-in-meetings
+      automatic_audio_output: {
+        in_call_recording: {
+          data: {
+            kind: 'mp3',
+            // Silent 1s MP3 — placeholder required to unlock output_audio endpoint
+            b64_data: 'SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjIwLjEwMAAAAAAAAAAAAAAA//OEAAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAA8AAAAEAAABIADAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDV1dXV1dXV1dXV1dXV1dXV1dXV1dXV1dXV6urq6urq6urq6urq6urq6urq6urq6urq6v////////////////////////////////8AAAAATGF2YzU4LjM1AAAAAAAAAAAAAAAAJAAAAAAAAAAAASDs90hvAAAAAAAAAAAAAAAAAAAA',
+          },
+        },
+      },
     },
     {
       headers: {


### PR DESCRIPTION
Per Recall.ai docs: to use the on-demand `output_audio` endpoint (ElevenLabs TTS injection), the bot must be created with `automatic_audio_output` configured. Added a silent 1s MP3 as the placeholder.\n\nWithout this, speak.ts voice injection would silently fail.\n\n221/221 tests.