### PR TITLE
fix: use EU Frankfurt Recall.ai region (eu-central-1)

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -6,7 +6,7 @@
 import axios from 'axios';
 import { z } from 'zod';
 
-const RECALL_API_BASE = 'https://us-east-1.recall.ai/api/v1';
+const RECALL_API_BASE = 'https://eu-central-1.recall.ai/api/v1';
 
 /**
  * Zod schema for Recall.ai bot creation response.
@@ -52,7 +52,7 @@ export async function joinMeeting(
   );
 
   const parsed = RecallJoinResponseSchema.parse(response.data);
-  const websocketUrl = `wss://us-east-1.recall.ai/api/v1/bot/${parsed.id}/transcript`;
+  const websocketUrl = `wss://eu-central-1.recall.ai/api/v1/bot/${parsed.id}/transcript`;
 
   return {
     botId: parsed.id,

--- a/src/listen.test.ts
+++ b/src/listen.test.ts
@@ -85,10 +85,10 @@ describe('streamTranscript', () => {
 
   it('connects with correct URL and authorization header', () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-123/transcript', 'sk-test-key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-123/transcript', 'sk-test-key', onSegment);
 
     const ws = latestWs();
-    expect(ws.url).toBe('wss://us-east-1.recall.ai/api/v1/bot/bot-123/transcript');
+    expect(ws.url).toBe('wss://eu-central-1.recall.ai/api/v1/bot/bot-123/transcript');
     expect(ws.options).toEqual(
       expect.objectContaining({
         headers: { Authorization: 'Token sk-test-key' },
@@ -102,7 +102,7 @@ describe('streamTranscript', () => {
 
   it('parses incoming Recall.ai transcript event and calls onSegment', async () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     sendTranscriptMessage(ws, {
@@ -127,7 +127,7 @@ describe('streamTranscript', () => {
 
   it('defaults speaker to null when missing from message', async () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     sendTranscriptMessage(ws, {
@@ -142,7 +142,7 @@ describe('streamTranscript', () => {
 
   it('ignores non-final transcript events', async () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     sendTranscriptMessage(ws, {
@@ -157,7 +157,7 @@ describe('streamTranscript', () => {
 
   it('ignores non-transcript event types', async () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockResolvedValue(undefined);
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     ws.emit('message', Buffer.from(JSON.stringify({ type: 'status', data: { status: 'active' } })));
@@ -175,7 +175,7 @@ describe('streamTranscript', () => {
     const onSegment = vi.fn<OnSegmentCallback>();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
     const ws = latestWs();
 
     // Send invalid JSON
@@ -196,7 +196,7 @@ describe('streamTranscript', () => {
     const onSegment = vi.fn<OnSegmentCallback>();
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
     const ws = latestWs();
 
     // Missing required 'words' field — fails RecallTranscriptDataSchema
@@ -219,7 +219,7 @@ describe('streamTranscript', () => {
 
   it('resolves on clean close (code 1000) without reconnecting', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    const promise = streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    const promise = streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
     ws.emit('close', 1000);
@@ -234,7 +234,7 @@ describe('streamTranscript', () => {
 
   it('reconnects with exponential backoff on unexpected close (up to 3 times)', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    const promise = streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    const promise = streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     // First connection -- unexpected close
     expect(instances).toHaveLength(1);
@@ -268,7 +268,7 @@ describe('streamTranscript', () => {
 
   it('reconnects then resolves if subsequent connection closes cleanly', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    const promise = streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    const promise = streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     // First connection -- unexpected close
     latestWs().emit('close', 1006);
@@ -291,7 +291,7 @@ describe('streamTranscript', () => {
     const onSegment = vi.fn<OnSegmentCallback>().mockRejectedValue(new Error('callback boom'));
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
     const ws = latestWs();
 
     sendTranscriptMessage(ws, {
@@ -319,7 +319,7 @@ describe('streamTranscript', () => {
 
   it('swallows WebSocket error events without crashing', async () => {
     const onSegment = vi.fn<OnSegmentCallback>();
-    streamTranscript('wss://us-east-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
+    streamTranscript('wss://eu-central-1.recall.ai/api/v1/bot/bot-1/transcript', 'key', onSegment);
 
     const ws = latestWs();
 

--- a/src/speak.test.ts
+++ b/src/speak.test.ts
@@ -91,7 +91,7 @@ describe('sendChatMessage', () => {
     await sendChatMessage('Hello meeting', mockConfigWithTTS, BOT_ID);
 
     expect(mockAxiosPost).toHaveBeenCalledWith(
-      'https://us-east-1.recall.ai/api/v1/bot/bot-123/send_chat_message/',
+      'https://eu-central-1.recall.ai/api/v1/bot/bot-123/send_chat_message/',
       { message: 'Hello meeting' },
       {
         headers: {
@@ -165,7 +165,7 @@ describe('respond', () => {
 
     // Chat message sent via REST API
     expect(mockAxiosPost).toHaveBeenCalledWith(
-      'https://us-east-1.recall.ai/api/v1/bot/bot-123/send_chat_message/',
+      'https://eu-central-1.recall.ai/api/v1/bot/bot-123/send_chat_message/',
       { message: 'Hello meeting' },
       expect.objectContaining({
         headers: expect.objectContaining({

--- a/src/speak.ts
+++ b/src/speak.ts
@@ -27,7 +27,7 @@ const MAX_TEXT_LENGTH = 200;
 /** Google Meet chat message character limit. */
 const CHAT_MESSAGE_MAX_LENGTH = 500;
 
-const RECALL_BASE_URL = 'https://us-east-1.recall.ai/api/v1';
+const RECALL_BASE_URL = 'https://eu-central-1.recall.ai/api/v1';
 
 /**
  * Send a text message into the Google Meet chat via Recall.ai REST API.


### PR DESCRIPTION
Account is on EU Frankfurt region. Was using us-east-1 → 401. Fixed all URLs to eu-central-1.recall.ai. 221/221 tests.