### PR TITLE
fix: harden webhook server — auth, tests, DRY extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 # Recall.ai — meeting bot service (recall.ai)
 RECALL_API_KEY=
+RECALL_WEBHOOK_SECRET=
+NGROK_URL=
 
 # ElevenLabs — text-to-speech (elevenlabs.io)
 ELEVENLABS_API_KEY=

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
       "devDependencies": {
         "@types/express": "^5.0.6",
         "@types/node": "^22.0.0",
+        "@types/supertest": "^7.2.0",
         "@types/ws": "^8.5.0",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vitest/coverage-v8": "^3.0.0",
         "eslint": "^9.0.0",
+        "supertest": "^7.2.2",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "vitest": "^3.0.0"
@@ -895,6 +897,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@octokit/auth-token": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
@@ -1077,6 +1092,16 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^25.1.0"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -1472,6 +1497,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1525,6 +1557,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.15.tgz",
@@ -1568,6 +1607,30 @@
       "dependencies": {
         "@types/http-errors": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-7.2.0.tgz",
+      "integrity": "sha512-uh2Lv57xvggst6lCqNdFAmDSvoMG7M/HDtX4iUCquxQ5EGPtaPM5PL5Hmi7LCvOG8db7YaCPNJEeoI8s/WzIQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
       }
     },
     "node_modules/@types/ws": {
@@ -2076,6 +2139,13 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2308,6 +2378,16 @@
       "integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
       "license": "MIT"
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2354,6 +2434,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2420,6 +2507,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -2945,6 +3043,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -3099,6 +3204,24 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -3714,6 +3837,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -4577,6 +4723,42 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
   "devDependencies": {
     "@types/express": "^5.0.6",
     "@types/node": "^22.0.0",
+    "@types/supertest": "^7.2.0",
     "@types/ws": "^8.5.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitest/coverage-v8": "^3.0.0",
     "eslint": "^9.0.0",
+    "supertest": "^7.2.2",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^3.0.0"

--- a/src/__tests__/extract-and-route.test.ts
+++ b/src/__tests__/extract-and-route.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for extract-and-route.ts — shared extraction + dedup + routing logic.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { OpenClawConfig } from '../config.js';
+import type { MeetingSession } from '../session.js';
+
+vi.mock('../detect.js', () => ({
+  extractIntents: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../route.js', () => ({
+  routeIntent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../dedup.js', () => ({
+  isDuplicate: vi.fn().mockReturnValue(false),
+}));
+
+import { extractAndRoute } from '../extract-and-route.js';
+import { extractIntents } from '../detect.js';
+import { isDuplicate } from '../dedup.js';
+import { routeIntent } from '../route.js';
+
+const TEST_CONFIG: OpenClawConfig = {
+  instanceName: 'TestBot',
+  recallApiKey: 'test-key',
+  elevenLabsApiKey: null,
+  geminiApiKey: 'test-gemini',
+  githubToken: null,
+  githubRepo: null,
+  telegramBotToken: null,
+  telegramChatId: null,
+  confidenceThreshold: 0.85,
+};
+
+function createMockSession(): MeetingSession {
+  return {
+    botId: 'bot-1',
+    meetingId: 'meeting-1',
+    intents: [],
+    addIntent: vi.fn(),
+  } as unknown as MeetingSession;
+}
+
+describe('extractAndRoute', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(extractIntents).mockResolvedValue([]);
+    vi.mocked(isDuplicate).mockReturnValue(false);
+    vi.mocked(routeIntent).mockResolvedValue(undefined);
+  });
+
+  it('extracts intents and routes non-duplicates', async () => {
+    const session = createMockSession();
+    const intent = {
+      id: 'i1',
+      type: 'BUG' as const,
+      text: 'login broken',
+      owner: null,
+      deadline: null,
+      priority: 'high' as const,
+      confidence: 0.9,
+      sourceQuote: 'login broken',
+    };
+    vi.mocked(extractIntents).mockResolvedValue([intent]);
+    vi.mocked(isDuplicate).mockReturnValue(false);
+
+    const count = await extractAndRoute('login is broken', session, TEST_CONFIG);
+
+    expect(count).toBe(1);
+    expect(session.addIntent).toHaveBeenCalledWith(intent);
+    expect(routeIntent).toHaveBeenCalledWith(intent, session, TEST_CONFIG);
+  });
+
+  it('skips duplicate intents', async () => {
+    const session = createMockSession();
+    vi.mocked(extractIntents).mockResolvedValue([
+      {
+        id: 'i1',
+        type: 'BUG',
+        text: 'dup',
+        owner: null,
+        deadline: null,
+        priority: 'high',
+        confidence: 0.9,
+        sourceQuote: 'dup',
+      },
+    ]);
+    vi.mocked(isDuplicate).mockReturnValue(true);
+
+    const count = await extractAndRoute('duplicate text', session, TEST_CONFIG);
+
+    expect(count).toBe(0);
+    expect(session.addIntent).not.toHaveBeenCalled();
+    expect(routeIntent).not.toHaveBeenCalled();
+  });
+
+  it('returns 0 when no intents are extracted', async () => {
+    const session = createMockSession();
+    vi.mocked(extractIntents).mockResolvedValue([]);
+
+    const count = await extractAndRoute('nothing actionable', session, TEST_CONFIG);
+
+    expect(count).toBe(0);
+  });
+
+  it('routes multiple intents from a single chunk', async () => {
+    const session = createMockSession();
+    vi.mocked(extractIntents).mockResolvedValue([
+      { id: 'i1', type: 'BUG', text: 'bug1', owner: null, deadline: null, priority: 'high', confidence: 0.9, sourceQuote: 'bug1' },
+      { id: 'i2', type: 'FEATURE', text: 'feat1', owner: null, deadline: null, priority: 'medium', confidence: 0.88, sourceQuote: 'feat1' },
+    ]);
+
+    const count = await extractAndRoute('bugs and features', session, TEST_CONFIG);
+
+    expect(count).toBe(2);
+    expect(routeIntent).toHaveBeenCalledTimes(2);
+  });
+
+  it('propagates extraction errors', async () => {
+    const session = createMockSession();
+    vi.mocked(extractIntents).mockRejectedValue(new Error('LLM timeout'));
+
+    await expect(extractAndRoute('text', session, TEST_CONFIG)).rejects.toThrow('LLM timeout');
+  });
+});

--- a/src/__tests__/webhook-server.test.ts
+++ b/src/__tests__/webhook-server.test.ts
@@ -1,0 +1,413 @@
+/**
+ * Tests for webhook-server.ts — Recall.ai webhook transcript receiver.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import crypto from 'node:crypto';
+import type { OpenClawConfig } from '../config.js';
+import type { MeetingSession } from '../session.js';
+
+// Mock dependencies before importing
+vi.mock('../detect.js', () => ({
+  extractIntents: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('../route.js', () => ({
+  routeIntent: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../dedup.js', () => ({
+  isDuplicate: vi.fn().mockReturnValue(false),
+}));
+vi.mock('../converse.js', () => ({
+  detectWakeWord: vi.fn().mockReturnValue(null),
+  handleAddressedSpeech: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('../summary.js', () => ({
+  generateAndSendSummary: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { createApp, registerSession, unregisterSession, _sessions } from '../webhook-server.js';
+import { extractIntents } from '../detect.js';
+import { isDuplicate } from '../dedup.js';
+import { routeIntent } from '../route.js';
+import { detectWakeWord, handleAddressedSpeech } from '../converse.js';
+import { generateAndSendSummary } from '../summary.js';
+
+const TEST_CONFIG: OpenClawConfig = {
+  instanceName: 'TestBot',
+  recallApiKey: 'test-key',
+  elevenLabsApiKey: null,
+  geminiApiKey: 'test-gemini',
+  githubToken: null,
+  githubRepo: null,
+  telegramBotToken: null,
+  telegramChatId: null,
+  confidenceThreshold: 0.85,
+};
+
+const BOT_ID = '550e8400-e29b-41d4-a716-446655440000';
+
+function makeTranscriptEvent(botId: string, text: string, speaker?: string) {
+  return {
+    event: 'transcript.data',
+    data: {
+      bot: { id: botId },
+      data: {
+        words: text.split(' ').map((w) => ({ text: w })),
+        participant: speaker ? { name: speaker } : undefined,
+      },
+    },
+  };
+}
+
+function createMockSession(): MeetingSession {
+  return {
+    botId: BOT_ID,
+    meetingId: 'test-meeting',
+    url: 'https://meet.google.com/abc-defg-hij',
+    startTime: new Date(),
+    config: TEST_CONFIG,
+    websocketUrl: null,
+    transcriptBuffer: [],
+    intents: [],
+    createdIssues: [],
+    decisions: [],
+    isActive: true,
+    addSegment: vi.fn(),
+    addIntent: vi.fn(),
+    addCreatedIssue: vi.fn(),
+    getTranscriptText: vi.fn().mockReturnValue(''),
+    end: vi.fn(),
+  } as unknown as MeetingSession;
+}
+
+describe('webhook-server', () => {
+  let app: ReturnType<typeof createApp>;
+  let mockSession: MeetingSession;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _sessions.clear();
+    delete process.env.RECALL_WEBHOOK_SECRET;
+
+    app = createApp(TEST_CONFIG);
+    mockSession = createMockSession();
+  });
+
+  afterEach(() => {
+    delete process.env.RECALL_WEBHOOK_SECRET;
+  });
+
+  describe('registerSession / unregisterSession', () => {
+    it('registers a session by botId', () => {
+      registerSession(mockSession);
+
+      expect(_sessions.has(BOT_ID)).toBe(true);
+      expect(_sessions.get(BOT_ID)!.session).toBe(mockSession);
+    });
+
+    it('throws if session has no botId', () => {
+      mockSession.botId = null;
+
+      expect(() => registerSession(mockSession)).toThrow('Cannot register session without botId');
+    });
+
+    it('unregisters a session by botId', () => {
+      registerSession(mockSession);
+      unregisterSession(BOT_ID);
+
+      expect(_sessions.has(BOT_ID)).toBe(false);
+    });
+  });
+
+  describe('POST / (transcript.data)', () => {
+    it('returns 200 for a valid transcript event', async () => {
+      registerSession(mockSession);
+      const body = makeTranscriptEvent(BOT_ID, 'hello world');
+
+      const res = await request(app).post('/').send(body);
+
+      expect(res.status).toBe(200);
+    });
+
+    it('adds transcript segment to session', async () => {
+      registerSession(mockSession);
+      const body = makeTranscriptEvent(BOT_ID, 'hello world', 'Alice');
+
+      await request(app).post('/').send(body);
+
+      expect(mockSession.addSegment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          text: 'hello world',
+          speaker: 'Alice',
+        }),
+      );
+    });
+
+    it('sets speaker to null when participant is missing', async () => {
+      registerSession(mockSession);
+      const body = makeTranscriptEvent(BOT_ID, 'hello');
+
+      await request(app).post('/').send(body);
+
+      expect(mockSession.addSegment).toHaveBeenCalledWith(
+        expect.objectContaining({ speaker: null }),
+      );
+    });
+
+    it('ignores non-transcript events', async () => {
+      registerSession(mockSession);
+
+      const res = await request(app)
+        .post('/')
+        .send({ event: 'bot.status_change', data: {} });
+
+      expect(res.status).toBe(200);
+      expect(mockSession.addSegment).not.toHaveBeenCalled();
+    });
+
+    it('ignores unknown botIds', async () => {
+      registerSession(mockSession);
+      const body = makeTranscriptEvent('unknown-bot', 'hello');
+
+      await request(app).post('/').send(body);
+
+      expect(mockSession.addSegment).not.toHaveBeenCalled();
+    });
+
+    it('ignores events with empty text', async () => {
+      registerSession(mockSession);
+      const body = {
+        event: 'transcript.data',
+        data: {
+          bot: { id: BOT_ID },
+          data: { words: [], participant: { name: 'Alice' } },
+        },
+      };
+
+      await request(app).post('/').send(body);
+
+      expect(mockSession.addSegment).not.toHaveBeenCalled();
+    });
+
+    it('triggers extraction after enough words accumulate', async () => {
+      registerSession(mockSession);
+      vi.mocked(extractIntents).mockResolvedValue([
+        {
+          id: 'i1',
+          type: 'BUG',
+          text: 'login is broken',
+          owner: null,
+          deadline: null,
+          priority: 'high',
+          confidence: 0.9,
+          sourceQuote: 'login is broken',
+        },
+      ]);
+
+      // Send enough words to trigger extraction (50+)
+      const longText = Array.from({ length: 55 }, (_, i) => `word${i}`).join(' ');
+      const body = makeTranscriptEvent(BOT_ID, longText, 'Bob');
+
+      await request(app).post('/').send(body);
+
+      // Wait for async processing
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(extractIntents).toHaveBeenCalled();
+      expect(routeIntent).toHaveBeenCalled();
+    });
+
+    it('does not extract before word threshold', async () => {
+      registerSession(mockSession);
+      const body = makeTranscriptEvent(BOT_ID, 'just a few words', 'Alice');
+
+      await request(app).post('/').send(body);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(extractIntents).not.toHaveBeenCalled();
+    });
+
+    it('skips duplicate intents', async () => {
+      registerSession(mockSession);
+      vi.mocked(extractIntents).mockResolvedValue([
+        {
+          id: 'i1',
+          type: 'BUG',
+          text: 'dup bug',
+          owner: null,
+          deadline: null,
+          priority: 'high',
+          confidence: 0.9,
+          sourceQuote: 'dup bug',
+        },
+      ]);
+      vi.mocked(isDuplicate).mockReturnValue(true);
+
+      const longText = Array.from({ length: 55 }, (_, i) => `word${i}`).join(' ');
+      await request(app).post('/').send(makeTranscriptEvent(BOT_ID, longText));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(routeIntent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('wake word detection', () => {
+    it('routes to Q&A when wake word detected', async () => {
+      registerSession(mockSession);
+      vi.mocked(detectWakeWord).mockReturnValue('what is the status?');
+
+      const body = makeTranscriptEvent(BOT_ID, 'hey TestBot what is the status', 'Alice');
+
+      await request(app).post('/').send(body);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(handleAddressedSpeech).toHaveBeenCalledWith(
+        'what is the status?',
+        mockSession,
+        TEST_CONFIG,
+      );
+    });
+
+    it('does not run extraction when wake word detected', async () => {
+      registerSession(mockSession);
+      vi.mocked(detectWakeWord).mockReturnValue('question?');
+
+      const longText = Array.from({ length: 55 }, (_, i) => `word${i}`).join(' ');
+      await request(app).post('/').send(makeTranscriptEvent(BOT_ID, longText));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(extractIntents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /bot-done', () => {
+    it('processes remaining buffer and generates summary', async () => {
+      registerSession(mockSession);
+
+      // Directly set buffer state (simulates accumulated transcript below extraction threshold)
+      const state = _sessions.get(BOT_ID)!;
+      state.buffer = 'we need to fix the login page';
+      state.wordCount = 7;
+
+      const res = await request(app)
+        .post('/bot-done')
+        .send({ bot: { id: BOT_ID } });
+
+      expect(res.status).toBe(200);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(extractIntents).toHaveBeenCalledWith('we need to fix the login page', TEST_CONFIG);
+      expect(generateAndSendSummary).toHaveBeenCalledWith(mockSession, TEST_CONFIG);
+    });
+
+    it('generates summary even with empty buffer', async () => {
+      registerSession(mockSession);
+
+      await request(app)
+        .post('/bot-done')
+        .send({ bot: { id: BOT_ID } });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(generateAndSendSummary).toHaveBeenCalledWith(mockSession, TEST_CONFIG);
+    });
+
+    it('unregisters session after processing', async () => {
+      registerSession(mockSession);
+
+      await request(app)
+        .post('/bot-done')
+        .send({ bot: { id: BOT_ID } });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(_sessions.has(BOT_ID)).toBe(false);
+    });
+
+    it('ignores unknown botIds', async () => {
+      const res = await request(app)
+        .post('/bot-done')
+        .send({ bot: { id: 'unknown' } });
+
+      expect(res.status).toBe(200);
+      expect(generateAndSendSummary).not.toHaveBeenCalled();
+    });
+
+    it('handles summary generation failure gracefully', async () => {
+      registerSession(mockSession);
+      vi.mocked(generateAndSendSummary).mockRejectedValue(new Error('Telegram down'));
+
+      await request(app)
+        .post('/bot-done')
+        .send({ bot: { id: BOT_ID } });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Should not throw — error is caught
+      expect(_sessions.has(BOT_ID)).toBe(false);
+    });
+  });
+
+  describe('webhook signature verification', () => {
+    it('rejects requests with invalid signature when secret is set', async () => {
+      process.env.RECALL_WEBHOOK_SECRET = 'test-secret';
+      app = createApp(TEST_CONFIG);
+      registerSession(mockSession);
+
+      const body = makeTranscriptEvent(BOT_ID, 'hello');
+
+      const res = await request(app)
+        .post('/')
+        .set('x-recall-signature', 'invalid-sig')
+        .send(body);
+
+      expect(res.status).toBe(401);
+      expect(mockSession.addSegment).not.toHaveBeenCalled();
+    });
+
+    it('accepts requests with valid HMAC signature', async () => {
+      const secret = 'test-secret';
+      process.env.RECALL_WEBHOOK_SECRET = secret;
+      app = createApp(TEST_CONFIG);
+      registerSession(mockSession);
+
+      const body = makeTranscriptEvent(BOT_ID, 'hello world');
+      const bodyStr = JSON.stringify(body);
+      const hmac = crypto.createHmac('sha256', secret).update(bodyStr).digest('hex');
+
+      const res = await request(app)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .set('x-recall-signature', hmac)
+        .send(bodyStr);
+
+      expect(res.status).toBe(200);
+      expect(mockSession.addSegment).toHaveBeenCalled();
+    });
+
+    it('allows all requests when no secret is configured', async () => {
+      delete process.env.RECALL_WEBHOOK_SECRET;
+      app = createApp(TEST_CONFIG);
+      registerSession(mockSession);
+
+      const body = makeTranscriptEvent(BOT_ID, 'hello');
+
+      const res = await request(app).post('/').send(body);
+
+      expect(res.status).toBe(200);
+      expect(mockSession.addSegment).toHaveBeenCalled();
+    });
+
+    it('rejects /bot-done with invalid signature', async () => {
+      process.env.RECALL_WEBHOOK_SECRET = 'test-secret';
+      app = createApp(TEST_CONFIG);
+      registerSession(mockSession);
+
+      const res = await request(app)
+        .post('/bot-done')
+        .set('x-recall-signature', 'bad')
+        .send({ bot: { id: BOT_ID } });
+
+      expect(res.status).toBe(401);
+      expect(generateAndSendSummary).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/extract-and-route.ts
+++ b/src/extract-and-route.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared extraction + dedup + routing logic.
+ * Used by both pipeline.ts (WebSocket) and webhook-server.ts (HTTP webhook).
+ */
+
+import type { MeetingSession } from './session.js';
+import type { OpenClawConfig } from './config.js';
+import { extractIntents } from './detect.js';
+import { isDuplicate } from './dedup.js';
+import { routeIntent } from './route.js';
+/**
+ * Extract intents from a transcript chunk, deduplicate, and route to actions.
+ * Returns the number of new intents routed.
+ */
+export async function extractAndRoute(
+  chunk: string,
+  session: MeetingSession,
+  config: OpenClawConfig,
+): Promise<number> {
+  const intents = await extractIntents(chunk, config);
+  let routed = 0;
+
+  for (const intent of intents) {
+    if (!isDuplicate(intent, session)) {
+      session.addIntent(intent);
+      await routeIntent(intent, session, config);
+      routed++;
+    }
+  }
+
+  return routed;
+}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -6,9 +6,7 @@
 import type { MeetingSession } from './session.js';
 import type { TranscriptSegment } from './models.js';
 import { streamTranscript } from './listen.js';
-import { extractIntents } from './detect.js';
-import { isDuplicate } from './dedup.js';
-import { routeIntent } from './route.js';
+import { extractAndRoute } from './extract-and-route.js';
 import { speakGreeting } from './speak.js';
 import { generateAndSendSummary } from './summary.js';
 import { detectWakeWord, handleAddressedSpeech } from './converse.js';
@@ -53,12 +51,7 @@ export async function runPipeline(session: MeetingSession): Promise<void> {
       lastExtractionTime = Date.now();
 
       try {
-        const intents = await extractIntents(chunk, config);
-        for (const intent of intents) {
-          if (!isDuplicate(intent, session)) {
-            await routeIntent(intent, session, config);
-          }
-        }
+        await extractAndRoute(chunk, session, config);
       } catch (err) {
         console.error('Extraction failed:', safeErrorMessage(err));
       }

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -12,8 +12,6 @@ import { safeErrorMessage } from './errors.js';
 
 const MEET_URL_REGEX = /https:\/\/meet\.google\.com\/[a-z]{3}-[a-z]{4}-[a-z]{3}/i;
 
-let webhookServerStarted = false;
-
 export function extractMeetUrl(message: string): string | null {
   const match = message.match(MEET_URL_REGEX);
   return match ? match[0] : null;
@@ -30,10 +28,7 @@ export async function handleMessage(
   const session = new MeetingSession(meetUrl, config);
 
   // Start webhook server once (receives Recall.ai transcript events)
-  if (!webhookServerStarted) {
-    startWebhookServer(4000);
-    webhookServerStarted = true;
-  }
+  startWebhookServer(4000, config);
 
   const ngrokUrl = process.env.NGROK_URL;
 

--- a/src/webhook-server.ts
+++ b/src/webhook-server.ts
@@ -1,141 +1,190 @@
 /**
  * Recall.ai webhook server — receives real-time transcript events and drives the pipeline.
- * Listens on port 4000, exposed via ngrok.
+ * Listens on a configurable port, exposed via ngrok.
  */
 
 import express from 'express';
-import { loadConfig } from './config.js';
-import { MeetingSession } from './session.js';
-import { extractIntents } from './detect.js';
-import { routeIntent } from './route.js';
-import { isDuplicate } from './dedup.js';
+import crypto from 'node:crypto';
+import type { OpenClawConfig } from './config.js';
+import type { MeetingSession } from './session.js';
+import type { TranscriptSegment } from './models.js';
+import { extractAndRoute } from './extract-and-route.js';
 import { detectWakeWord, handleAddressedSpeech } from './converse.js';
 import { generateAndSendSummary } from './summary.js';
-import type { TranscriptSegment } from './models.js';
+import { safeErrorMessage } from './errors.js';
 
-const app = express();
-app.use(express.json());
+const EXTRACTION_INTERVAL_WORDS = 50;
+
+interface SessionState {
+  session: MeetingSession;
+  buffer: string;
+  wordCount: number;
+}
 
 // Active meeting sessions keyed by botId
-const sessions = new Map<string, MeetingSession>();
+const sessions = new Map<string, SessionState>();
 
-// Rolling transcript buffer per session
-const buffers = new Map<string, string>();
-const EXTRACTION_INTERVAL_WORDS = 50; // extract after ~50 words
-const wordCounts = new Map<string, number>();
+let serverStarted = false;
 
-const config = loadConfig();
+/**
+ * Verify Recall.ai webhook signature (HMAC-SHA256).
+ * Returns true if RECALL_WEBHOOK_SECRET is not set (allows unsigned dev mode).
+ */
+function verifySignature(rawBody: Buffer, signature: string | undefined): boolean {
+  const secret = process.env.RECALL_WEBHOOK_SECRET;
+  if (!secret) return true; // No secret configured — skip verification (dev mode)
+  if (!signature) return false;
+
+  const expected = crypto
+    .createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('hex');
+
+  const sigBuf = Buffer.from(signature, 'utf8');
+  const expBuf = Buffer.from(expected, 'utf8');
+  if (sigBuf.length !== expBuf.length) return false;
+
+  return crypto.timingSafeEqual(sigBuf, expBuf);
+}
 
 /**
  * Register a session so the webhook server can process its transcript.
  */
 export function registerSession(session: MeetingSession): void {
-  sessions.set(session.botId!, session);
-  buffers.set(session.botId!, '');
-  wordCounts.set(session.botId!, 0);
+  if (!session.botId) throw new Error('Cannot register session without botId');
+  sessions.set(session.botId, { session, buffer: '', wordCount: 0 });
   console.log(`[webhook] Session registered for bot ${session.botId}`);
 }
 
 export function unregisterSession(botId: string): void {
   sessions.delete(botId);
-  buffers.delete(botId);
-  wordCounts.delete(botId);
+}
+
+function createApp(config: OpenClawConfig): express.Express {
+  const app = express();
+
+  // Parse JSON but also keep raw body for signature verification
+  app.use(express.json({
+    verify: (req: express.Request & { rawBody?: Buffer }, _res, buf) => {
+      req.rawBody = buf;
+    },
+  }));
+
+  /**
+   * POST / — Recall.ai sends transcript.data events here
+   */
+  app.post('/', async (req: express.Request & { rawBody?: Buffer }, res: express.Response) => {
+    const signature = req.headers['x-recall-signature'] as string | undefined;
+    if (!verifySignature(req.rawBody ?? Buffer.alloc(0), signature)) {
+      res.sendStatus(401);
+      return;
+    }
+
+    res.sendStatus(200);
+
+    const event = req.body;
+    if (event?.event !== 'transcript.data') return;
+
+    const botId: string | undefined = event?.data?.bot?.id;
+    if (!botId) return;
+
+    const state = sessions.get(botId);
+    if (!state) return;
+
+    const words: Array<{ text: string }> = event?.data?.data?.words ?? [];
+    const text = words.map((w: { text: string }) => w.text).join(' ').trim();
+    if (!text) return;
+
+    const speakerName: string | null = event?.data?.data?.participant?.name ?? null;
+    const segment: TranscriptSegment = {
+      text,
+      speaker: speakerName,
+      timestamp: Date.now(),
+    };
+
+    state.session.addSegment(segment);
+    console.log(`[webhook] ${speakerName ?? 'Unknown'}: ${text}`);
+
+    // Check wake word first
+    const question = detectWakeWord(segment, config.instanceName);
+    if (question !== null && question.length > 0) {
+      console.log(`[webhook] Wake word detected: "${question}"`);
+      handleAddressedSpeech(question, state.session, config).catch((err) => {
+        console.error('[webhook] Q&A handler failed:', safeErrorMessage(err));
+      });
+      return;
+    }
+
+    // Accumulate buffer for intent extraction
+    state.buffer += ' ' + text;
+    state.wordCount += words.length;
+
+    if (state.wordCount >= EXTRACTION_INTERVAL_WORDS) {
+      const chunk = state.buffer;
+      state.buffer = '';
+      state.wordCount = 0;
+
+      try {
+        await extractAndRoute(chunk, state.session, config);
+      } catch (err) {
+        console.error('[webhook] Extraction error:', safeErrorMessage(err));
+      }
+    }
+  });
+
+  /**
+   * POST /bot-done — called when bot leaves the meeting
+   */
+  app.post('/bot-done', async (req: express.Request & { rawBody?: Buffer }, res: express.Response) => {
+    const signature = req.headers['x-recall-signature'] as string | undefined;
+    if (!verifySignature(req.rawBody ?? Buffer.alloc(0), signature)) {
+      res.sendStatus(401);
+      return;
+    }
+
+    res.sendStatus(200);
+
+    const botId: string | undefined = req.body?.bot?.id;
+    if (!botId) return;
+
+    const state = sessions.get(botId);
+    if (!state) return;
+
+    // Process any remaining buffer
+    const remaining = state.buffer.trim();
+    if (remaining) {
+      try {
+        await extractAndRoute(remaining, state.session, config);
+      } catch (err) {
+        console.error('[webhook] Final extraction error:', safeErrorMessage(err));
+      }
+    }
+
+    try {
+      await generateAndSendSummary(state.session, config);
+    } catch (err) {
+      console.error('[webhook] Summary generation failed:', safeErrorMessage(err));
+    }
+
+    unregisterSession(botId);
+    console.log(`[webhook] Session ended for bot ${botId}`);
+  });
+
+  return app;
 }
 
 /**
- * POST / — Recall.ai sends transcript.data events here
+ * Start the webhook server. No-op if already started.
  */
-app.post('/', async (req, res) => {
-  res.sendStatus(200); // Acknowledge immediately
+export function startWebhookServer(port: number, config: OpenClawConfig): void {
+  if (serverStarted) return;
+  serverStarted = true;
 
-  const event = req.body;
-  if (event?.event !== 'transcript.data') return;
-
-  const botId = event?.data?.bot?.id;
-  if (!botId) return;
-
-  const session = sessions.get(botId);
-  if (!session) return;
-
-  // Extract text from words array
-  const words: Array<{ text: string }> = event?.data?.data?.words ?? [];
-  const text = words.map((w) => w.text).join(' ').trim();
-  if (!text) return;
-
-  const speakerName: string = event?.data?.data?.participant?.name ?? null;
-  const segment: TranscriptSegment = {
-    text,
-    speaker: speakerName,
-    timestamp: Date.now(),
-  };
-
-  session.addSegment(segment);
-  console.log(`[webhook] ${speakerName ?? 'Unknown'}: ${text}`);
-
-  // Check wake word first
-  const question = detectWakeWord(segment, config.instanceName);
-  if (question !== null && question.length > 0) {
-    console.log(`[webhook] Wake word detected: "${question}"`);
-    handleAddressedSpeech(question, session, config).catch(console.error);
-    return; // Don't also run intent extraction on this segment
-  }
-
-  // Accumulate buffer for intent extraction
-  const current = (buffers.get(botId) ?? '') + ' ' + text;
-  buffers.set(botId, current);
-  const count = (wordCounts.get(botId) ?? 0) + words.length;
-  wordCounts.set(botId, count);
-
-  if (count >= EXTRACTION_INTERVAL_WORDS) {
-    buffers.set(botId, '');
-    wordCounts.set(botId, 0);
-    try {
-      const intents = await extractIntents(current, config);
-      for (const intent of intents) {
-        if (!isDuplicate(intent, session)) {
-          session.addIntent(intent);
-          await routeIntent(intent, session, config);
-        }
-      }
-    } catch (err) {
-      console.error('[webhook] Extraction error:', err instanceof Error ? err.message : err);
-    }
-  }
-});
-
-/**
- * POST /bot-done — called when bot leaves the meeting
- */
-app.post('/bot-done', async (req, res) => {
-  res.sendStatus(200);
-  const botId = req.body?.bot?.id;
-  if (!botId) return;
-  const session = sessions.get(botId);
-  if (!session) return;
-
-  // Process any remaining buffer
-  const remaining = buffers.get(botId) ?? '';
-  if (remaining.trim()) {
-    try {
-      const intents = await extractIntents(remaining, config);
-      for (const intent of intents) {
-        if (!isDuplicate(intent, session)) {
-          session.addIntent(intent);
-          await routeIntent(intent, session, config);
-        }
-      }
-    } catch (err) {
-      console.error('[webhook] Final extraction error:', err instanceof Error ? err.message : err);
-    }
-  }
-
-  await generateAndSendSummary(session, config);
-  unregisterSession(botId);
-  console.log(`[webhook] Session ended for bot ${botId}`);
-});
-
-export function startWebhookServer(port = 4000): void {
+  const app = createApp(config);
   app.listen(port, () => {
     console.log(`[webhook] Server listening on port ${port}`);
   });
 }
+
+// Exported for testing
+export { createApp, sessions as _sessions };


### PR DESCRIPTION
## Summary
- **HMAC-SHA256 webhook authentication**: Verifies `X-Recall-Signature` header when `RECALL_WEBHOOK_SECRET` is set (dev mode allows unsigned requests)
- **Fix broken test suite**: Removed module-level `loadConfig()` in `webhook-server.ts` that crashed `skill.test.ts` on import (15 tests were failing)
- **DRY extraction logic**: Extracted shared `extractIntents → isDuplicate → routeIntent` loop into `src/extract-and-route.ts`, used by both `pipeline.ts` and `webhook-server.ts`
- **Type safety**: Fixed `speakerName: string` assigned `null` → now correctly typed `string | null`
- **Error handling**: Wrapped `generateAndSendSummary` in try/catch in `/bot-done` handler (prevents unhandled rejection crash on Node 22)
- **Idempotent server start**: Moved `webhookServerStarted` guard into `startWebhookServer()` itself
- **28 new tests**: Full coverage for webhook-server (23 tests) and extract-and-route (5 tests)

Addresses review findings from PR #35.

## Test plan
- [x] All 249 tests pass (was 206 with 1 suite failing before fix)
- [x] `tsc --noEmit` clean
- [x] `eslint src/` clean
- [ ] Verify webhook signature rejection with a real Recall.ai webhook secret
- [ ] Test ngrok flow end-to-end with a real Google Meet call

🤖 Generated with [Claude Code](https://claude.com/claude-code)