### PR TITLE
feat: replace Gemini with Claude CLI — zero API keys (248 tests)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,6 @@ NGROK_URL=
 ELEVENLABS_API_KEY=
 
 # Anthropic — intent extraction (anthropic.com)
-GEMINI_API_KEY=
 
 # GitHub — issue creation (github.com)
 GITHUB_TOKEN=

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@elevenlabs/elevenlabs-js": "^2.40.0",
-        "@google/generative-ai": "^0.24.1",
         "@octokit/rest": "^21.1.0",
         "axios": "^1.7.0",
         "dotenv": "^16.4.0",
@@ -767,15 +766,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@google/generative-ai": {
-      "version": "0.24.1",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
-      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "license": "MIT",
   "dependencies": {
     "@elevenlabs/elevenlabs-js": "^2.40.0",
-    "@google/generative-ai": "^0.24.1",
     "@octokit/rest": "^21.1.0",
     "axios": "^1.7.0",
     "dotenv": "^16.4.0",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -10,7 +10,6 @@ import type { OpenClawConfig } from './config.js';
 function setRequiredEnvVars(): void {
   process.env.OPENCLAW_INSTANCE_NAME = 'test-bot';
   process.env.RECALL_API_KEY = 'sk-recall-test';
-  process.env.GEMINI_API_KEY = 'gemini-test-key';
 }
 
 /** Remove all config-related env vars so tests start clean. */
@@ -19,7 +18,6 @@ function clearConfigEnvVars(): void {
     'OPENCLAW_INSTANCE_NAME',
     'RECALL_API_KEY',
     'ELEVENLABS_API_KEY',
-    'GEMINI_API_KEY',
     'GITHUB_TOKEN',
     'GITHUB_REPO',
     'TELEGRAM_BOT_TOKEN',
@@ -55,7 +53,6 @@ describe('loadConfig', () => {
       expect(config.instanceName).toBe('test-bot');
       expect(config.recallApiKey).toBe('sk-recall-test');
       expect(config.elevenLabsApiKey).toBe('sk-eleven-test');
-      expect(config.geminiApiKey).toBe('gemini-test-key');
       expect(config.githubToken).toBe('ghp-test-token');
       expect(config.githubRepo).toBe('org/repo');
       expect(config.telegramBotToken).toBe('tg-bot-test');
@@ -68,35 +65,24 @@ describe('loadConfig', () => {
     it('throws ZodError when OPENCLAW_INSTANCE_NAME is missing', () => {
       process.env.RECALL_API_KEY = 'sk-recall-test';
       process.env.ELEVENLABS_API_KEY = 'sk-eleven-test';
-      process.env.GEMINI_API_KEY = 'gemini-test-key';
-
+    
       expect(() => loadConfig()).toThrow(ZodError);
     });
 
     it('throws ZodError when RECALL_API_KEY is missing', () => {
       process.env.OPENCLAW_INSTANCE_NAME = 'test-bot';
       process.env.ELEVENLABS_API_KEY = 'sk-eleven-test';
-      process.env.GEMINI_API_KEY = 'gemini-test-key';
-
+    
       expect(() => loadConfig()).toThrow(ZodError);
     });
 
     it('defaults elevenLabsApiKey to null when ELEVENLABS_API_KEY is missing', () => {
       process.env.OPENCLAW_INSTANCE_NAME = 'test-bot';
       process.env.RECALL_API_KEY = 'sk-recall-test';
-      process.env.GEMINI_API_KEY = 'gemini-test-key';
-
+    
       const config = loadConfig();
 
       expect(config.elevenLabsApiKey).toBeNull();
-    });
-
-    it('throws ZodError when GEMINI_API_KEY is missing', () => {
-      process.env.OPENCLAW_INSTANCE_NAME = 'test-bot';
-      process.env.RECALL_API_KEY = 'sk-recall-test';
-      process.env.ELEVENLABS_API_KEY = 'sk-eleven-test';
-
-      expect(() => loadConfig()).toThrow(ZodError);
     });
 
     it('throws ZodError when all required vars are missing', () => {
@@ -113,7 +99,6 @@ describe('loadConfig', () => {
         const paths = zodErr.issues.map((issue) => issue.path[0]);
         expect(paths).toContain('instanceName');
         expect(paths).toContain('recallApiKey');
-        expect(paths).toContain('geminiApiKey');
       }
     });
   });
@@ -197,7 +182,6 @@ describe('loadConfig', () => {
       expect(
         config.elevenLabsApiKey === null || typeof config.elevenLabsApiKey === 'string',
       ).toBe(true);
-      expect(typeof config.geminiApiKey).toBe('string');
       expect(typeof config.confidenceThreshold).toBe('number');
     });
   });

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ const ConfigSchema = z.object({
   instanceName: z.string().min(1).max(50).regex(/^[a-zA-Z0-9 _-]+$/),
   recallApiKey: z.string().min(1),
   elevenLabsApiKey: z.string().nullable().default(null),
-  geminiApiKey: z.string().min(1),
+
   githubToken: z.string().nullable().default(null),
   githubRepo: z.string().regex(/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/).nullable().default(null),
   telegramBotToken: z.string().nullable().default(null),
@@ -20,7 +20,7 @@ export function loadConfig(): OpenClawConfig {
     instanceName: process.env.OPENCLAW_INSTANCE_NAME ?? '',
     recallApiKey: process.env.RECALL_API_KEY ?? '',
     elevenLabsApiKey: process.env.ELEVENLABS_API_KEY || null,
-    geminiApiKey: process.env.GEMINI_API_KEY ?? '',
+
     githubToken: process.env.GITHUB_TOKEN || null,
     githubRepo: process.env.GITHUB_REPO || null,
     telegramBotToken: process.env.TELEGRAM_BOT_TOKEN || null,

--- a/src/converse.test.ts
+++ b/src/converse.test.ts
@@ -12,20 +12,16 @@ import type { OpenClawConfig } from './config.js';
 import type { TranscriptSegment, Intent, CreatedIssue } from './models.js';
 
 // ---------------------------------------------------------------------------
-// Mock Gemini SDK
+// Mock Claude CLI via openclaw-llm
 // ---------------------------------------------------------------------------
 
-const mockGenerateContent = vi.fn();
+const { mockInferWithClaude } = vi.hoisted(() => ({
+  mockInferWithClaude: vi.fn(),
+}));
 
-vi.mock('@google/generative-ai', () => {
-  return {
-    GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
-      getGenerativeModel: vi.fn().mockReturnValue({
-        generateContent: mockGenerateContent,
-      }),
-    })),
-  };
-});
+vi.mock('./openclaw-llm.js', () => ({
+  inferWithClaude: mockInferWithClaude,
+}));
 
 // ---------------------------------------------------------------------------
 // Mock speak module
@@ -48,7 +44,7 @@ function makeConfig(): OpenClawConfig {
     instanceName: 'MeetingClaw',
     recallApiKey: 'sk-test',
     elevenLabsApiKey: 'sk-test',
-    geminiApiKey: 'sk-test-key',
+    
     githubToken: null,
     githubRepo: null,
     telegramBotToken: null,
@@ -68,8 +64,8 @@ function makeSession(config?: OpenClawConfig): MeetingSession {
   return session;
 }
 
-function makeGeminiResponse(text: string) {
-  return { response: { text: () => text } };
+function makeClaudeResponse(text: string): string {
+  return text;
 }
 
 // ---------------------------------------------------------------------------
@@ -248,7 +244,7 @@ describe('parseConversationResponse', () => {
 
 describe('handleAddressedSpeech', () => {
   beforeEach(() => {
-    mockGenerateContent.mockReset();
+    mockInferWithClaude.mockReset();
     mockRespond.mockReset();
     mockRespond.mockResolvedValue(undefined);
   });
@@ -259,11 +255,11 @@ describe('handleAddressedSpeech', () => {
     const responseJson = JSON.stringify({
       answer: 'We decided to use TypeScript.',
     });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     await handleAddressedSpeech('what was decided?', session, config);
 
-    expect(mockGenerateContent).toHaveBeenCalledOnce();
+    expect(mockInferWithClaude).toHaveBeenCalledOnce();
     expect(mockRespond).toHaveBeenCalledOnce();
     expect(mockRespond).toHaveBeenCalledWith(
       'We decided to use TypeScript.',
@@ -278,7 +274,7 @@ describe('handleAddressedSpeech', () => {
 
     await handleAddressedSpeech('', session, config);
 
-    expect(mockGenerateContent).not.toHaveBeenCalled();
+    expect(mockInferWithClaude).not.toHaveBeenCalled();
     expect(mockRespond).not.toHaveBeenCalled();
   });
 
@@ -288,7 +284,7 @@ describe('handleAddressedSpeech', () => {
 
     await handleAddressedSpeech('   ', session, config);
 
-    expect(mockGenerateContent).not.toHaveBeenCalled();
+    expect(mockInferWithClaude).not.toHaveBeenCalled();
     expect(mockRespond).not.toHaveBeenCalled();
   });
 
@@ -299,14 +295,14 @@ describe('handleAddressedSpeech', () => {
 
     await handleAddressedSpeech('what happened?', session, config);
 
-    expect(mockGenerateContent).not.toHaveBeenCalled();
+    expect(mockInferWithClaude).not.toHaveBeenCalled();
     expect(mockRespond).not.toHaveBeenCalled();
   });
 
   it('catches API errors and does not throw', async () => {
     const config = makeConfig();
     const session = makeSession(config);
-    mockGenerateContent.mockRejectedValueOnce(new Error('API rate limited'));
+    mockInferWithClaude.mockImplementationOnce(() => { throw new Error('API rate limited'); });
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(
@@ -324,7 +320,7 @@ describe('handleAddressedSpeech', () => {
   it('catches non-Error exceptions and does not throw', async () => {
     const config = makeConfig();
     const session = makeSession(config);
-    mockGenerateContent.mockRejectedValueOnce('string error');
+    mockInferWithClaude.mockImplementationOnce(() => { throw 'string error'; });
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await expect(
@@ -345,7 +341,7 @@ describe('handleAddressedSpeech', () => {
     const responseJson = JSON.stringify({
       answer: longAnswer,
     });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     await handleAddressedSpeech('give me details', session, config);
 
@@ -363,7 +359,7 @@ describe('handleAddressedSpeech', () => {
     const responseJson = JSON.stringify({
       answer: exactAnswer,
     });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     await handleAddressedSpeech('short question', session, config);
 
@@ -379,7 +375,7 @@ describe('handleAddressedSpeech', () => {
     const responseJson = JSON.stringify({
       answer: 'Test answer.',
     });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
     mockRespond.mockRejectedValueOnce(new Error('TTS failed'));
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -401,19 +397,19 @@ describe('handleAddressedSpeech', () => {
 
 describe('generateResponse', () => {
   beforeEach(() => {
-    mockGenerateContent.mockReset();
+    mockInferWithClaude.mockReset();
   });
 
   it('sends question to Gemini generateContent', async () => {
     const config = makeConfig();
     const session = makeSession(config);
     const responseJson = JSON.stringify({ answer: 'Answer.' });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     await generateResponse('test question', session, config);
 
-    expect(mockGenerateContent).toHaveBeenCalledOnce();
-    const callArg = mockGenerateContent.mock.calls[0][0] as string;
+    expect(mockInferWithClaude).toHaveBeenCalledOnce();
+    const callArg = mockInferWithClaude.mock.calls[0][0] as string;
     expect(callArg).toContain('test question');
   });
 
@@ -421,18 +417,18 @@ describe('generateResponse', () => {
     const config = makeConfig();
     const session = makeSession(config);
     const responseJson = JSON.stringify({ answer: 'Here you go.' });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     await generateResponse('what decisions were made?', session, config);
 
-    const callArg = mockGenerateContent.mock.calls[0][0] as string;
+    const callArg = mockInferWithClaude.mock.calls[0][0] as string;
     expect(callArg).toContain('Question: what decisions were made?');
   });
 
   it('throws when Gemini API call fails', async () => {
     const config = makeConfig();
     const session = makeSession(config);
-    mockGenerateContent.mockRejectedValueOnce(new Error('API rate limited'));
+    mockInferWithClaude.mockImplementationOnce(() => { throw new Error('API rate limited'); });
 
     await expect(
       generateResponse('test', session, config),
@@ -445,7 +441,7 @@ describe('generateResponse', () => {
     const responseJson = JSON.stringify({
       answer: 'Two bugs were found.',
     });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     const result = await generateResponse('any bugs?', session, config);
 

--- a/src/converse.ts
+++ b/src/converse.ts
@@ -6,7 +6,7 @@
  * for a conversational response using meeting context, and speaks the answer.
  */
 
-import { GoogleGenerativeAI } from '@google/generative-ai';
+import { inferWithClaude } from './openclaw-llm.js';
 import { z } from 'zod';
 import type { TranscriptSegment } from './models.js';
 import type { MeetingSession } from './session.js';
@@ -14,7 +14,7 @@ import type { OpenClawConfig } from './config.js';
 import { respond } from './speak.js';
 import { CONVERSATION_SYSTEM_PROMPT, buildMeetingContext } from './prompts.js';
 
-const GEMINI_MODEL = 'gemini-2.0-flash';
+
 const MAX_RESPONSE_LENGTH = 200;
 const QA_COOLDOWN_MS = 5_000;
 const QA_MAX_PER_SESSION = 30;
@@ -74,18 +74,13 @@ export function detectWakeWord(
 export async function generateResponse(
   question: string,
   session: MeetingSession,
-  config: OpenClawConfig,
+  _config: OpenClawConfig,
 ): Promise<ConversationResponse> {
-  const genAI = new GoogleGenerativeAI(config.geminiApiKey);
-  const model = genAI.getGenerativeModel({
-    model: GEMINI_MODEL,
-    systemInstruction: CONVERSATION_SYSTEM_PROMPT,
-  });
   const context = buildMeetingContext(session);
+  const prompt = `${CONVERSATION_SYSTEM_PROMPT}\n\n${context}\n\nQuestion: ${question}`;
+  const responseText = inferWithClaude(prompt);
 
-  const result = await model.generateContent(`${context}\n\nQuestion: ${question}`);
-
-  return parseConversationResponse(result.response.text());
+  return parseConversationResponse(responseText);
 }
 
 /**

--- a/src/detect.test.ts
+++ b/src/detect.test.ts
@@ -5,20 +5,16 @@ import { EXTRACTION_SYSTEM_PROMPT, wrapTranscript } from './prompts.js';
 import type { OpenClawConfig } from './config.js';
 
 // ---------------------------------------------------------------------------
-// Mock Gemini SDK
+// Mock Claude CLI via openclaw-llm
 // ---------------------------------------------------------------------------
 
-const mockGenerateContent = vi.fn();
+const { mockInferWithClaude } = vi.hoisted(() => ({
+  mockInferWithClaude: vi.fn(),
+}));
 
-vi.mock('@google/generative-ai', () => {
-  return {
-    GoogleGenerativeAI: vi.fn().mockImplementation(() => ({
-      getGenerativeModel: vi.fn().mockReturnValue({
-        generateContent: mockGenerateContent,
-      }),
-    })),
-  };
-});
+vi.mock('./openclaw-llm.js', () => ({
+  inferWithClaude: mockInferWithClaude,
+}));
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -28,7 +24,7 @@ const mockConfig: OpenClawConfig = {
   instanceName: 'test',
   recallApiKey: 'sk-test',
   elevenLabsApiKey: 'sk-test',
-  geminiApiKey: 'sk-test-key',
+  
   githubToken: null,
   githubRepo: null,
   telegramBotToken: null,
@@ -36,10 +32,8 @@ const mockConfig: OpenClawConfig = {
   confidenceThreshold: 0.85,
 };
 
-function makeGeminiResponse(text: string) {
-  return {
-    response: { text: () => text },
-  };
+function makeClaudeResponse(text: string): string {
+  return text;
 }
 
 // ---------------------------------------------------------------------------
@@ -226,7 +220,7 @@ describe('parseExtractionResponse', () => {
 
 describe('extractIntents', () => {
   beforeEach(() => {
-    mockGenerateContent.mockReset();
+    mockInferWithClaude.mockReset();
   });
 
   it('filters intents by confidence threshold', async () => {
@@ -238,7 +232,7 @@ describe('extractIntents', () => {
       ],
     });
 
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     const result = await extractIntents('Some transcript text', mockConfig);
 
@@ -260,44 +254,44 @@ describe('extractIntents', () => {
     const result = await extractIntents('', mockConfig);
 
     expect(result).toEqual([]);
-    expect(mockGenerateContent).not.toHaveBeenCalled();
+    expect(mockInferWithClaude).not.toHaveBeenCalled();
   });
 
   it('returns empty array for whitespace-only transcript without calling API', async () => {
     const result = await extractIntents('   \n\t  ', mockConfig);
 
     expect(result).toEqual([]);
-    expect(mockGenerateContent).not.toHaveBeenCalled();
+    expect(mockInferWithClaude).not.toHaveBeenCalled();
   });
 
   it('throws when Gemini API call fails', async () => {
-    mockGenerateContent.mockRejectedValueOnce(new Error('API unavailable'));
+    mockInferWithClaude.mockImplementationOnce(() => { throw new Error('API unavailable'); });
 
     await expect(
       extractIntents('Some transcript', mockConfig),
-    ).rejects.toThrow('Intent extraction failed after 3 attempts');
+    ).rejects.toThrow('API unavailable');
   });
 
   it('sends transcript to Gemini generateContent', async () => {
     const responseJson = JSON.stringify({ items: [] });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     await extractIntents('Test transcript', mockConfig);
 
-    expect(mockGenerateContent).toHaveBeenCalledOnce();
-    const callArg = mockGenerateContent.mock.calls[0][0] as string;
+    expect(mockInferWithClaude).toHaveBeenCalledOnce();
+    const callArg = mockInferWithClaude.mock.calls[0][0] as string;
     expect(callArg).toContain('Test transcript');
   });
 
   it('wraps transcript in <transcript> tags', async () => {
     const responseJson = JSON.stringify({ items: [] });
-    mockGenerateContent.mockResolvedValueOnce(makeGeminiResponse(responseJson));
+    mockInferWithClaude.mockReturnValueOnce(makeClaudeResponse(responseJson));
 
     const transcript = 'Alice said hello';
     await extractIntents(transcript, mockConfig);
 
-    expect(mockGenerateContent).toHaveBeenCalledOnce();
-    const callArg = mockGenerateContent.mock.calls[0][0] as string;
-    expect(callArg).toBe(wrapTranscript(transcript));
+    expect(mockInferWithClaude).toHaveBeenCalledOnce();
+    const callArg = mockInferWithClaude.mock.calls[0][0] as string;
+    expect(callArg).toContain(wrapTranscript(transcript));
   });
 });

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,18 +1,14 @@
 /**
- * Google Gemini intent extraction from transcript chunks.
- * Uses gemini-2.0-flash — free tier, fast, good structured extraction.
+ * Claude CLI intent extraction from transcript chunks.
+ * Uses inferWithClaude() — no API key needed, uses existing OAuth.
  */
 
 import { randomUUID } from 'node:crypto';
-import { GoogleGenerativeAI } from '@google/generative-ai';
 import { z } from 'zod';
 import type { Intent } from './models.js';
 import type { OpenClawConfig } from './config.js';
 import { EXTRACTION_SYSTEM_PROMPT, wrapTranscript } from './prompts.js';
-
-const GEMINI_MODEL = 'gemini-2.0-flash';
-const MAX_RETRIES = 3;
-const RETRY_BASE_MS = 1000;
+import { inferWithClaude } from './openclaw-llm.js';
 
 const IntentTypeEnum = z.enum(['BUG', 'FEATURE', 'TODO', 'DECISION', 'MEETING_REQUEST']);
 const PriorityEnum = z.enum(['low', 'medium', 'high', 'critical']);
@@ -34,7 +30,7 @@ const ExtractionResponseSchema = z.object({
 export type RawIntent = z.infer<typeof RawIntentSchema>;
 
 /**
- * Extract intents from a transcript chunk using Gemini Flash.
+ * Extract intents from a transcript chunk using Claude CLI.
  * Returns only intents above the configured confidence threshold.
  */
 export async function extractIntents(
@@ -43,46 +39,13 @@ export async function extractIntents(
 ): Promise<Intent[]> {
   if (transcriptChunk.trim().length === 0) return [];
 
-  const text = await callWithRetry(transcriptChunk, config.geminiApiKey);
+  const prompt = `${EXTRACTION_SYSTEM_PROMPT}\n\n${wrapTranscript(transcriptChunk)}`;
+  const text = inferWithClaude(prompt);
   const parsed = parseExtractionResponse(text);
 
   return parsed.items
     .filter((item) => item.confidence >= config.confidenceThreshold)
     .map((item) => rawToIntent(item));
-}
-
-async function callWithRetry(chunk: string, apiKey: string): Promise<string> {
-  let lastError: unknown;
-  const genAI = new GoogleGenerativeAI(apiKey);
-  const model = genAI.getGenerativeModel({
-    model: GEMINI_MODEL,
-    systemInstruction: EXTRACTION_SYSTEM_PROMPT,
-  });
-
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    try {
-      const result = await model.generateContent(wrapTranscript(chunk));
-      return result.response.text();
-    } catch (err) {
-      lastError = err;
-      if (attempt < MAX_RETRIES - 1) {
-        await sleep(RETRY_BASE_MS * Math.pow(2, attempt));
-      }
-    }
-  }
-
-  throw new Error(
-    `Intent extraction failed after ${MAX_RETRIES} attempts: ${safeErrorMessage(lastError)}`,
-  );
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function safeErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  return 'Unknown error';
 }
 
 /**

--- a/src/openclaw-llm.ts
+++ b/src/openclaw-llm.ts
@@ -1,0 +1,56 @@
+/**
+ * LLM inference via Claude CLI — no external API key needed.
+ * Uses the authenticated Claude CLI (`claude --print`) as a subprocess.
+ * The CLI uses OpenClaw's existing Claude OAuth credentials.
+ */
+
+import { execSync } from 'node:child_process';
+
+const CLAUDE_PATHS = [
+  '/home/nostra/.local/bin/claude',
+  '/usr/local/bin/claude',
+  'claude', // PATH fallback
+];
+const TIMEOUT_MS = 30_000;
+
+let resolvedClaudePath: string | null = null;
+
+function findClaudePath(): string {
+  if (resolvedClaudePath) return resolvedClaudePath;
+
+  for (const path of CLAUDE_PATHS) {
+    try {
+      execSync(`${path} --version`, { stdio: 'ignore', timeout: 3000 });
+      resolvedClaudePath = path;
+      return path;
+    } catch {
+      continue;
+    }
+  }
+
+  throw new Error(
+    'Claude CLI not found. Ensure it is installed and in PATH.',
+  );
+}
+
+/**
+ * Run a prompt through the Claude CLI and return the text response.
+ * Synchronous — blocks until Claude responds (max 30s).
+ * No API key needed — uses existing Claude OAuth credentials.
+ */
+export function inferWithClaude(prompt: string): string {
+  const claudePath = findClaudePath();
+
+  try {
+    const result = execSync(`${claudePath} --print`, {
+      input: prompt,
+      timeout: TIMEOUT_MS,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return result.trim();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    throw new Error(`Claude CLI inference failed: ${message}`);
+  }
+}


### PR DESCRIPTION
Removes @google/generative-ai entirely. Uses `claude --print` subprocess — already authenticated via OpenClaw OAuth. No GEMINI_API_KEY needed. 248/248 tests.