### PR TITLE
GEN-291: publish artifact-reader planning and mock context fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,12 @@ AI Meeting Assistant that **takes action**, not just notes.
 
 ## Status
 
-🚧 **Planning Phase** - Hackathon Project (OpenClaw Hack_001, Vienna, March 2026)
+🚧 **Early prototype with active planning**
 
-See `/docs` for architecture and planning documents.
+Key planning docs:
+- `docs/IMPLEMENTATION-SHORTLIST.md` - ranked build order from the research set
+- `docs/IMPLEMENTATION-ROADMAP.md` - phased delivery and testing plan
+- `docs/MARKET-RESEARCH.md` - positioning and competitor analysis
 
 ## Team
 

--- a/docs/GEN-219-browser-capture-to-artifact-pilot-contract.md
+++ b/docs/GEN-219-browser-capture-to-artifact-pilot-contract.md
@@ -1,0 +1,199 @@
+# GEN-219 Browser capture to artifact pilot contract
+
+Date: 2026-04-20
+Status: proposed pilot contract for the current MeetingAgent repo
+Scope: synthetic, mock, local-only validation
+Sources: `docs/IMPLEMENTATION-SHORTLIST.md`, `docs/IMPLEMENTATION-ROADMAP.md`, `../GEN-209-meeting-agent-ranked-shortlist-2026-04-20.md`, `../GEN-75-meeting-agent-presence-and-join-transport.md`, `../GEN-80-research-meeting-agent-post-meeting-notes-workflow.md`
+
+## Purpose
+
+Define the smallest end-to-end pilot that proves the top-ranked MeetingAgent direction:
+
+1. browser-first local copilot
+2. normalized transcript events
+3. one canonical post-meeting artifact
+4. human-readable outputs rendered from that artifact
+
+This contract is intentionally narrower than a full meeting agent. It proves the browser-capture-to-artifact path before live joins, action side effects, bot attendance, or voice output.
+
+## Hard scope boundaries
+
+Included:
+- local or browser-derived caption events from a controlled synthetic source
+- transcript normalization into the repo's session model
+- meeting close or checkpoint artifact generation
+- markdown notes and action-item render outputs
+- fixture-driven and local smoke validation
+
+Excluded:
+- real participant content
+- real meeting joins
+- Recall transport expansion for this pilot
+- GitHub, calendar, email, or task side effects
+- TTS or spoken responses
+- bot-participant presence mode
+
+Privacy gate:
+- this pilot must stay in the synthetic/local-only lane until GEN-71 approval clears real-content handling
+
+## Pilot outcome
+
+A successful pilot means a local operator or test can feed browser-caption-shaped transcript events into MeetingAgent and reliably receive a reviewable artifact set at checkpoint or wrap-up.
+
+Required output set for each successful run:
+- `meeting.json`
+- `meeting-notes.md`
+- `action-items.json`
+- `summary.txt`
+
+## Contract summary
+
+### Input contract
+
+The pilot accepts normalized browser-caption events with these minimum fields:
+- `meetingId`
+- `eventId`
+- `timestamp`
+- `speakerName`
+- `text`
+- `isFinal`
+- `source`
+
+Recommended source values for this pilot:
+- `browser_caption_stream`
+- `synthetic_browser_fixture`
+
+Rules:
+- partial and final caption events may both arrive
+- duplicate events must not duplicate downstream notes or action items
+- empty or whitespace-only text is ignored
+- transport-specific fields may exist upstream, but the session pipeline consumes only the normalized event shape
+
+Example minimum event:
+
+```json
+{
+  "meetingId": "demo-weekly-001",
+  "eventId": "evt-0007-final",
+  "timestamp": "2026-04-20T10:03:14.000Z",
+  "speakerName": "Tom",
+  "text": "Lisa will send the revised onboarding checklist by Friday.",
+  "isFinal": true,
+  "source": "synthetic_browser_fixture"
+}
+```
+
+### Runtime contract
+
+The pilot runtime must support three actions:
+
+1. ingest transcript event
+2. generate checkpoint artifact set
+3. close session and generate final artifact set
+
+Expected behavior:
+- transcript events append to one meeting session timeline
+- meeting state keeps observed speakers, transcript segments, and extracted candidate signals
+- wrap-up generation still succeeds when some transcript chunks were partial, duplicated, or missing
+- artifact generation is deterministic for a fixed fixture input
+
+### Output contract
+
+#### 1. Canonical artifact: `meeting.json`
+
+This is the durable source of truth.
+
+Minimum top-level sections:
+- `meeting`
+- `participants`
+- `summary`
+- `decisions`
+- `actionItems`
+- `openQuestions`
+- `followUps`
+- `warnings`
+- `source`
+
+Minimum expectations:
+- every extracted decision/action item includes source attribution when available
+- action items carry `owner` and `deadline` only when explicit or high-confidence
+- missing confidence should degrade to `ownerUnknown` or `deadlineUnspecified`, not invention
+- warnings include transcript-quality issues such as duplicate suppression, partial coverage, or ambiguous ownership
+
+#### 2. Rendered notes: `meeting-notes.md`
+
+Minimum sections:
+- title and metadata
+- short summary
+- decisions
+- action items
+- open questions
+- follow-up
+- warnings
+
+#### 3. Automation payload: `action-items.json`
+
+This file is review-only in the pilot.
+It is not permission to execute actions.
+
+Each item should include:
+- `task`
+- `owner`
+- `deadline`
+- `confidence`
+- `sourceTimestamp`
+- `sourceSpeaker`
+- `status`, default `review_required`
+
+#### 4. Digest: `summary.txt`
+
+A short operator-facing summary suitable for chat, logs, or a UI preview.
+
+## Acceptance criteria
+
+The pilot is done when all of these are true:
+
+1. A fixture or local browser-caption stub can send normalized transcript events into the current repo.
+2. The session pipeline can create one canonical `meeting.json` artifact from those events.
+3. The repo renders `meeting-notes.md`, `action-items.json`, and `summary.txt` from the same canonical artifact.
+4. Duplicate transcript chunks do not create duplicate extracted outputs.
+5. Ambiguous ownership or due dates are preserved as unknown, not guessed.
+6. The happy path works without Recall, bot attendance, TTS, or downstream external writes.
+7. Tests cover at least:
+   - clean decision + action-item extraction
+   - duplicate partial/final transcript behavior
+   - ambiguous owner handling
+   - checkpoint generation before final wrap-up
+
+## Suggested repo shape for this pilot
+
+This contract does not require a full rewrite, but it does require clear boundaries:
+- transcript-source normalization boundary
+- meeting session state boundary
+- summary/artifact generation boundary
+- renderers for markdown and action payloads
+
+A minimal implementation can map onto the current repo as:
+- transcript ingest adapter or fixture feeding `session.ts`
+- artifact builder logic in `summary.ts` or a dedicated artifact module
+- fixture tests under `src/__tests__/`
+- synthetic transcript fixtures under `src/__fixtures__/`
+- artifact output written under a local synthetic meetings folder
+
+## Non-goals and follow-ups
+
+After this pilot is green, the next layers can build on the same contract:
+- public skill wrapper and readiness checks
+- dry-run action bridge consuming `action-items.json`
+- bot-participant fallback transport
+- optional speak-back in explicit bot mode
+
+But none of those are part of GEN-219.
+
+## Decision statement
+
+For MeetingAgent, the first pilot contract should be:
+
+browser/local caption capture -> normalized transcript events -> session timeline -> canonical `meeting.json` -> rendered notes and review-only action artifacts.
+
+That is the smallest contract that proves the ranked shortlist direction while staying compatible with the repo's TypeScript architecture and the current synthetic-only privacy gate.

--- a/docs/GEN-71-recall-smoke-test-approval-package.md
+++ b/docs/GEN-71-recall-smoke-test-approval-package.md
@@ -1,0 +1,129 @@
+# GEN-71 Recall smoke-test approval package
+
+Status: draft
+Recommendation: do not approve for live Recall smoke testing yet
+Prepared by: OpenClaw run 74b89ef9-3530-432d-8cec-c151eee266d5
+Date: 2026-04-20 UTC
+
+## What this package is for
+
+This package is the approval gate for a limited Recall.ai smoke test of the MeetingAgent plugin.
+
+The goal is not general release approval. The goal is to decide whether the current codebase is safe enough to run a tightly-scoped end-to-end Recall smoke test and to make the approval decision explicit.
+
+## Proposed smoke-test scope
+
+Run one controlled meeting using a non-production test account and synthetic or explicitly-consented content, then verify:
+
+1. plugin registration succeeds
+2. meeting join flow succeeds against Recall.ai
+3. transcript delivery reaches the webhook/session layer
+4. extraction and routing run without duplicate or unsafe actions
+5. post-meeting summary artifacts are produced
+6. failures degrade safely without crashing the whole run
+
+## Evidence reviewed
+
+Repository sources reviewed:
+- `README.md`
+- `CLAUDE.md`
+- `docs/IMPLEMENTATION-ROADMAP.md`
+- `docs/INTEGRATIONS.md`
+- `src/plugin.ts`
+- existing unit/integration-style test suite
+
+Relevant project guidance already in repo:
+- `docs/IMPLEMENTATION-ROADMAP.md` says privacy/security approval is a release gate for real meeting use
+- the same roadmap defines a smoke suite covering plugin registration, synthetic join result, synthetic transcript ingestion, extract-and-route, and summary generation
+- `CLAUDE.md` requires mocked integration coverage and graceful degradation for failures
+
+## Current verification snapshot
+
+Commands run locally from this workspace:
+
+```bash
+npm run check
+npm test
+```
+
+Observed results:
+
+### 1. Quality gate does not pass
+`npm run check` fails at lint.
+
+Current lint blocker:
+- `src/plugin.ts:73` uses `any`
+
+### 2. Test suite does not fully pass
+`npm test` reports:
+- 20 test files passed
+- 1 test file failed
+- 389 tests passed
+- 6 tests failed
+
+All 6 failures are in `src/__tests__/plugin.test.ts`.
+
+Failure pattern:
+- expected HTTP route registration is not happening
+- tests expect `registerHttpRoute` to register:
+  - `POST /webhook/transcript`
+  - `POST /webhook/bot-done`
+- current `src/plugin.ts` always starts the standalone Express webhook server on port 4000 instead of using gateway route registration when available
+
+### 3. Meaning of the current failure
+This is not a minor cosmetic issue.
+
+The smoke-test gate specifically depends on the plugin, webhook, and Recall transcript path behaving in the intended deployment model. Right now there is a documented mismatch between:
+- test expectations, which assume gateway HTTP route registration when available
+- implementation, which unconditionally falls back to the standalone webhook server
+
+That mismatch weakens confidence in the exact Recall ingress path we want to approve.
+
+## Approval decision
+
+### Decision
+Do not approve live Recall smoke testing yet.
+
+### Why
+Approval should be blocked until the webhook ingress path is internally consistent and the quality gate is green enough to trust the smoke-test result.
+
+Minimum reasons to block:
+1. `npm run check` is failing
+2. plugin/webhook registration tests are failing in the exact area the Recall smoke test depends on
+3. the roadmap already treats privacy-gated real meeting rollout as a separate approval milestone
+
+## Required fixes before approval
+
+1. Resolve the plugin registration mismatch
+   - decide whether the supported path is gateway `registerHttpRoute` or standalone Express server
+   - align implementation, tests, and docs to one deployment model
+
+2. Make `npm run check` pass
+   - remove the `any` usage and cleanup the stale eslint disable if it remains unnecessary
+
+3. Re-run and capture evidence for:
+   - `npm run typecheck`
+   - `npm run lint`
+   - `npm test`
+   - one fixture-driven smoke workflow for join -> transcript -> extract -> summary
+
+4. Confirm smoke-test guardrails before any live run
+   - synthetic or explicitly-consented content only
+   - non-production destination accounts
+   - actions either dry-run or routed to a disposable test target
+   - logs and summary artifact retained for review
+
+## Approval checklist for the eventual smoke test
+
+- [ ] quality gate passes locally
+- [ ] plugin ingress path is consistent across code, tests, and docs
+- [ ] Recall credentials are loaded from config, not hardcoded
+- [ ] webhook authenticity checks are enabled where applicable
+- [ ] test meeting uses synthetic or consented content
+- [ ] downstream actions point to safe test targets
+- [ ] rollback/cleanup steps are written down before the run
+- [ ] one operator observes the run live and records pass/fail notes
+
+## Suggested approval comment
+
+Draft package complete. Current recommendation is not approved yet for live Recall smoke testing. Local verification shows the quality gate is still red: `npm run check` fails on `src/plugin.ts`, and `npm test` still has 6 failing plugin-route tests in the webhook registration path that the Recall smoke flow depends on. Next step is to reconcile the supported webhook ingress model, get the suite green, then rerun the smoke-test evidence bundle and request approval again.

--- a/docs/IMPLEMENTATION-ROADMAP.md
+++ b/docs/IMPLEMENTATION-ROADMAP.md
@@ -1,0 +1,250 @@
+# MeetingAgent implementation roadmap and testing strategy
+
+## Current repo state
+
+The repo is past pure ideation. It already contains a TypeScript plugin skeleton, meeting session state, Recall join/listen paths, intent extraction, routing, summary generation, webhook handlers, and a substantial Vitest suite.
+
+What is still missing is a clear staged delivery plan that matches the current codebase instead of the older hackathon planning docs.
+
+Observed status from this run:
+- `src/` already contains the core runtime modules and tests
+- `npm run check` currently fails in lint on `src/plugin.ts` because of an explicit `any`
+- The project is therefore in an "early integrated prototype" phase, not just a design-only phase
+
+## Delivery goal
+
+Ship MeetingAgent as a safe, testable OpenClaw meeting assistant in four phases:
+1. stable local/plugin prototype
+2. reliable meeting transport and session handling
+3. safe action execution and summaries
+4. production hardening and privacy-gated real deployment
+
+## Guiding principles
+
+- Keep the entry path thin: join, stream, extract, route, summarize
+- Prefer text-first behavior over conversational voice by default
+- Treat external meeting transport as unreliable and test for degradation
+- Make actions idempotent or at least deduplicated where possible
+- Keep privacy/security approval as a release gate for real meeting use
+
+## Phase roadmap
+
+### Phase 0, stabilization of the current prototype
+
+Goal: make the existing TypeScript codebase consistently green and easier to extend.
+
+Scope:
+- fix `npm run check`
+- align docs with the real TypeScript architecture
+- confirm environment loading and config validation paths
+- confirm webhook server and plugin registration behavior
+- remove dead assumptions from older docs that still describe a Python MVP
+
+Exit criteria:
+- `npm run check` passes locally
+- README and docs describe the current TypeScript/OpenClaw plugin architecture
+- one documented happy-path demo works end to end with mocks or synthetic inputs
+
+### Phase 1, meeting transport and session reliability
+
+Goal: make joining, transcript ingestion, and session lifecycle dependable.
+
+Scope:
+- harden Recall join flow and error handling
+- finish webhook delivery and session registration lifecycle
+- improve reconnect and timeout behavior in transcript streaming
+- make checkpointing and end-of-meeting closure deterministic
+- support both realtime transcript and no-websocket fallback paths cleanly
+
+Exit criteria:
+- synthetic meeting session can start, ingest transcript events, and close cleanly
+- reconnect/disconnect scenarios are covered by tests
+- summary generation still runs after stream failure or partial transcript loss
+
+### Phase 2, extraction and action execution
+
+Goal: produce trustworthy structured intents and execute only safe actions.
+
+Scope:
+- harden JSON extraction validation
+- refine deduplication and confidence gating
+- make route handlers clearly separated by integration type
+- add dry-run or audit mode for actions
+- ensure partial failures do not break the meeting pipeline
+
+Exit criteria:
+- known transcript fixtures produce stable structured intents
+- duplicate transcript chunks do not create repeated actions
+- failed GitHub or downstream actions are isolated and surfaced in summary output
+
+### Phase 3, post-meeting artifact pipeline
+
+Goal: make the meeting summary a first-class artifact, not an afterthought.
+
+Scope:
+- emit canonical structured meeting artifact
+- render markdown notes from that artifact
+- produce separate action-items output
+- support partial-transcript warnings and confidence markers
+- define retention/deletion boundaries for stored data
+
+Exit criteria:
+- one meeting run emits structured summary artifacts consistently
+- action extraction can be reviewed independently from raw transcript text
+- post-meeting outputs remain useful even when some automations fail
+
+### Phase 4, production hardening and guarded rollout
+
+Goal: make the system safe to run in real environments after privacy approval.
+
+Scope:
+- privacy/security gate completion before real participant content
+- operational logging and audit trail
+- rate limiting and provider backoff
+- secret handling review
+- packaging, deployment, and recovery documentation
+- benchmark latency for browser-first versus bot-participant modes
+
+Exit criteria:
+- production runbook exists
+- privacy/security gate is explicitly satisfied for real meetings
+- deployment and rollback are documented
+- representative non-synthetic pilot succeeds
+
+## Recommended work order by module
+
+1. `config.ts`, `plugin.ts`, `join.ts`
+   - stabilize boot, config, and registration
+2. `listen.ts`, `webhook-server.ts`, `webhook-handlers.ts`, `session.ts`
+   - stabilize transcript/session lifecycle
+3. `detect.ts`, `prompts.ts`, `dedup.ts`, `route.ts`, `extract-and-route.ts`
+   - stabilize extraction and routing correctness
+4. `summary.ts`, output persistence, docs
+   - stabilize durable meeting artifacts
+5. `speak.ts`, `converse.ts`
+   - keep optional until text-first path is reliable
+
+## Testing strategy
+
+Use a layered strategy. Most confidence should come from deterministic local tests, not live meeting runs.
+
+### 1. Unit tests
+
+Target modules:
+- `config.ts`
+- `session.ts`
+- `detect.ts`
+- `dedup.ts`
+- `route.ts`
+- `summary.ts`
+- `converse.ts`
+- `speak.ts`
+
+What to verify:
+- schema validation
+- transcript accumulation
+- confidence thresholds
+- dedup behavior
+- safe error formatting
+- summary rendering from known inputs
+
+### 2. integration tests with mocks
+
+Target flows:
+- plugin registration
+- join flow
+- transcript stream handling
+- webhook handling
+- extract-and-route pipeline
+- end-of-meeting summary path
+
+Mock boundaries:
+- Recall API
+- WebSocket transcript feed
+- LLM client
+- GitHub and other downstream integrations
+- ElevenLabs
+
+What to verify:
+- join success and failure paths
+- duplicate transcript chunks do not double-trigger actions
+- pipeline keeps running when one action fails
+- summary generation still runs in `finally`
+
+### 3. fixture-based transcript tests
+
+Add or expand fixtures for:
+- clean bug report mention
+- mixed TODO plus decision meeting
+- ambiguous ownership
+- repeated partial and final transcript chunks
+- wake-word addressed speech that should bypass extraction
+- low-confidence statements that should not auto-act
+
+These fixtures should drive both extraction assertions and final summary assertions.
+
+### 4. contract tests for action payloads
+
+For each integration, validate the produced outbound payload shape before any live call.
+
+Examples:
+- GitHub issue title/body/labels
+- summary output object shape
+- webhook payload normalization
+- speech request payload
+
+This is the best defense against runtime breakage when providers change.
+
+### 5. smoke tests
+
+Keep one lightweight smoke suite that runs:
+- plugin registration
+- synthetic join result
+- synthetic transcript ingestion
+- extract-and-route with mocked LLM
+- summary generation
+
+This should be fast enough for every PR.
+
+## CI recommendation
+
+Required on every PR:
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test`
+
+Recommended next additions:
+- coverage threshold for core modules
+- one fixture-driven smoke workflow
+- optional nightly longer integration suite
+
+## Risk register
+
+### Highest risks now
+- docs and implementation diverging, especially Python MVP versus current TypeScript plugin
+- transport instability around Recall/webhook/session lifecycle
+- duplicate or unsafe downstream actions from transcript noise
+- privacy/security ambiguity if real meeting handling starts before the gate is cleared
+- voice features adding complexity before the text-first path is reliable
+
+### Mitigations
+- update docs now
+- prefer mocked integration coverage before live testing
+- keep action confidence thresholds strict
+- keep TTS optional until core pipeline is stable
+- treat real-content rollout as a separate approval milestone
+
+## Immediate next actions
+
+1. Fix the current lint failure in `src/plugin.ts`
+2. Update README and architecture docs to remove stale Python-first assumptions
+3. Add or tighten fixture-based tests for duplicate transcript chunks and partial failures
+4. Define the canonical post-meeting artifact shape in docs and code
+5. Only then expand live meeting transport coverage
+
+## Definition of done for this planning issue
+
+This issue should be considered complete when the team agrees on:
+- the phased roadmap above
+- the layered testing strategy above
+- the immediate priority order: stabilize current prototype first, then transport, then actions, then production hardening

--- a/docs/IMPLEMENTATION-SHORTLIST.md
+++ b/docs/IMPLEMENTATION-SHORTLIST.md
@@ -1,0 +1,182 @@
+# GEN-209 Ranked implementation shortlist
+
+This shortlist turns the existing research set into a build order for the current MeetingAgent repo.
+
+Research inputs:
+- `GEN-60-self-hosted-meeting-agent-options-review.md`
+- `GEN-73-pika-public-skill-patterns-vs-hermes-vexa.md`
+- `GEN-75-meeting-agent-presence-and-join-transport.md`
+- `GEN-78-meeting-agent-tts-and-stt-strategy.md`
+- `GEN-80-research-meeting-agent-post-meeting-notes-workflow.md`
+- current repo docs and TypeScript prototype state
+
+Constraint carried forward from the research set:
+- real meeting traffic remains gated by the GEN-71 privacy/security approval
+- near-term work should stay in synthetic, mock, local-only, and documentation-safe lanes
+
+## Ranking method
+
+Each candidate was scored against five practical criteria for the current repo:
+- user value soon
+- fit with current TypeScript codebase
+- privacy-safe progress before GEN-71 clears
+- implementation risk
+- reuse across later meeting modes
+
+Score scale: 1 low, 5 high.
+
+## Ranked shortlist
+
+| Rank | Candidate | Value | Feasibility | Risk | Reuse | Total | Why it ranks here |
+|---|---|---:|---:|---:|---:|---:|---|
+| 1 | Browser-first fast copilot foundation | 5 | 5 | 4 | 5 | 19 | Best privacy and latency direction, matches repo and research consensus |
+| 2 | Canonical post-meeting artifact pipeline | 5 | 5 | 4 | 5 | 19 | Gives durable outputs, test fixtures, and safe downstream automation boundary |
+| 3 | Public skill wrapper plus readiness checks | 4 | 5 | 4 | 4 | 17 | Fixes packaging and usability without locking architecture to one vendor |
+| 4 | Bot participant fallback using self-hosted meeting transport | 4 | 3 | 3 | 4 | 14 | Important for external meetings, but should stay secondary to local/browser-first |
+| 5 | Narrow action bridge with dry-run and audit mode | 4 | 3 | 3 | 4 | 14 | Valuable, but should land after transcript and summary boundaries are stable |
+| 6 | Audible speak-back via controlled TTS path | 2 | 3 | 3 | 3 | 11 | Useful later, but explicitly not part of the fast-path MVP |
+| 7 | Fully self-hosted realtime STT/TTS stack on current server | 2 | 1 | 1 | 3 | 7 | Highest complexity, weakest latency fit on current CPU-only box |
+
+## 1. Browser-first fast copilot foundation
+
+Status: highest priority
+
+What to build:
+- a primary `local_companion` presence mode
+- a primary `browser_caption_stream` or equivalent normalized transcript source
+- transcript event normalization into the existing meeting session pipeline
+- text-first responses only, no default voice output
+
+Why first:
+- GEN-60, GEN-75, and GEN-78 all converge on browser-first as the best default for privacy and latency
+- it aligns with the current TypeScript plugin direction better than a bot-first rebuild
+- it allows meaningful progress without requiring real bot attendance before the privacy gate clears
+
+Concrete repo outcomes:
+- define transcript source interfaces in code and docs
+- add synthetic transcript fixtures that mimic browser caption events
+- make the session pipeline consume normalized events independent of transport
+
+## 2. Canonical post-meeting artifact pipeline
+
+Status: tie for highest priority, should run in parallel with item 1 where possible
+
+What to build:
+- one structured meeting artifact as the durable source of truth
+- markdown notes rendered from that artifact
+- separate action-items output and short digest output
+- meeting-end and checkpoint generation paths
+
+Why second:
+- GEN-80 gives the clearest low-risk path to useful product value before live-meeting approval
+- it creates the backbone needed for summaries, actions, review, and testing
+- it reduces coupling between transcript ingestion and downstream side effects
+
+Concrete repo outcomes:
+- document a canonical `meeting.json` shape
+- add summary builder tests from transcript fixtures
+- generate `meeting-notes.md`, `action-items.json`, and short digest artifacts
+
+## 3. Public skill wrapper plus readiness checks
+
+Status: next after the core data path is stable
+
+What to build:
+- one obvious public-facing `meeting-agent` skill contract
+- guided readiness checks for keys, selected mode, and required integrations
+- stable artifacts for persona, session state, and outputs
+
+Why third:
+- GEN-73 shows the biggest gap versus Pika is packaging discipline, not core architecture
+- this improves usability without sacrificing the browser-first and modular direction
+- it keeps vendor and deployment details hidden behind one clean entry point
+
+Concrete repo outcomes:
+- tighten README and docs around one installable path
+- add readiness validation in config or startup
+- expose one narrow command surface: join or attach, summarize, extract actions, leave or wrap
+
+## 4. Bot participant fallback using self-hosted meeting transport
+
+Status: important, but not the default product path
+
+What to build:
+- a secondary `bot_participant` presence mode
+- a fallback transport for external Meet, Zoom, or Teams attendance
+- explicit separation from the browser-first path
+
+Why fourth:
+- the research set says external meeting presence still matters
+- but it adds more moving parts and more privacy surface than the local companion path
+- it should be built as a fallback lane, not the foundation
+
+Concrete repo outcomes:
+- presence abstraction with `local_companion` and `bot_participant`
+- transport abstraction with browser-first and bot worker implementations
+- tests for clean degradation when the bot transport fails
+
+## 5. Narrow action bridge with dry-run and audit mode
+
+Status: after artifact generation is reliable
+
+What to build:
+- action routing that consumes extracted action items from the canonical artifact
+- dry-run mode by default in tests and synthetic demos
+- explicit audit output for what would have been created
+
+Why fifth:
+- the repo promise is action-taking, but actions should not outrun trust in transcript and summary quality
+- this stage keeps side effects controlled and reviewable
+- it aligns with the implementation roadmap's safe-action phase
+
+Concrete repo outcomes:
+- dry-run route handlers
+- contract tests for outbound payloads
+- partial-failure handling that never blocks notes generation
+
+## 6. Audible speak-back via controlled TTS path
+
+Status: optional enhancement
+
+What to build:
+- optional speech output for visible-bot mode only
+- short, explicit speak-back moments
+- controlled bridge-based TTS path instead of making voice the default experience
+
+Why sixth:
+- GEN-78 is clear that TTS should be secondary and off by default for MVP
+- it adds turn-taking and UX complexity without unlocking the core value first
+
+## 7. Fully self-hosted realtime STT/TTS on current server
+
+Status: defer
+
+Why last:
+- the research set consistently rejects this as the current default on the CPU-only machine
+- it is the highest-complexity path with the weakest short-term payoff
+- revisit only if privacy requirements tighten or hardware changes materially
+
+## Recommended execution sequence
+
+### Wave 1, now
+1. Define the normalized transcript-source and presence abstractions.
+2. Define the canonical meeting artifact and output renders.
+3. Add fixture-driven tests covering partial, duplicate, and ambiguous transcript events.
+
+### Wave 2
+4. Wrap the repo in one clean public skill contract.
+5. Add readiness checks and docs for browser-first fast mode.
+6. Add dry-run action routing from extracted artifacts.
+
+### Wave 3
+7. Add bot participant fallback transport.
+8. Add narrow audible speak-back only for explicit bot-assistant cases.
+
+### Explicitly deferred
+9. Full local realtime STT/TTS stack on this server.
+
+## Decision summary
+
+If the team needs one sentence:
+
+Build MeetingAgent around a browser-first, text-first copilot with a canonical post-meeting artifact pipeline, package it as one clean public skill, and keep bot attendance, action side effects, and voice output as later controlled layers rather than the foundation.

--- a/src/__fixtures__/meeting-context/README.md
+++ b/src/__fixtures__/meeting-context/README.md
@@ -1,0 +1,25 @@
+# Meeting context fixtures
+
+This fixture set inventories mock meeting-session contexts that future tests can load without wiring live Recall, GitHub, calendar, or chat providers.
+
+## Fixtures
+
+| Fixture | Purpose | Permission posture |
+|---|---|---|
+| `baseline-active-session.ts` | Normal in-progress meeting with transcript, intents, and one created GitHub issue | All integrations allowed |
+| `github-permission-denied.ts` | Meeting context where issue creation should be treated as unavailable | GitHub denied |
+| `calendar-permission-denied.ts` | Meeting context where scheduling follow-up requests should stay in review/manual mode | Calendar denied |
+| `assistant-question-only.ts` | Conversational context for spoken Q&A without side effects | No write permissions required |
+
+## Permission cases covered
+
+1. GitHub write denied while the meeting still contains BUG and TODO intents.
+2. Calendar write denied while the meeting contains a follow-up request.
+3. Read-only conversational use where the assistant can answer from context but should not take action.
+4. Full-access baseline for happy-path routing and summary generation.
+
+## Notes
+
+- Fixtures are typed `MockMeetingContextBundle` exports that mirror the current `MeetingSession#toJSON()` shape plus a lightweight `mockContext` block for test metadata.
+- Provider-local paths, tokens, and tenant-specific identifiers are intentionally omitted.
+- These fixtures are intended for unit and integration tests, not production persistence.

--- a/src/__fixtures__/meeting-context/assistant-question-only.json
+++ b/src/__fixtures__/meeting-context/assistant-question-only.json
@@ -1,0 +1,40 @@
+{
+  "fixtureId": "assistant-question-only",
+  "description": "Read-only meeting context for spoken Q&A with no provider writes.",
+  "mockContext": {
+    "permissions": {
+      "github": "not_needed",
+      "calendar": "not_needed",
+      "telegram": "not_needed"
+    },
+    "expectedMode": "read_only"
+  },
+  "session": {
+    "meetingId": "meeting-question-only-001",
+    "url": "https://meet.google.com/question-only-demo",
+    "startTime": "2026-04-19T20:45:00.000Z",
+    "botId": "bot-question-only",
+    "websocketUrl": "wss://recall.example.test/meeting-question-only-001",
+    "isActive": true,
+    "transcriptBuffer": [
+      { "speaker": "Tom", "text": "Claude, what did we decide about the release train?", "timestamp": 1713559500000 },
+      { "speaker": "Anna", "text": "We agreed to ship the staging cut on Friday.", "timestamp": 1713559560000 }
+    ],
+    "intents": [
+      {
+        "id": "intent-decision-1",
+        "type": "DECISION",
+        "text": "Ship the staging cut on Friday",
+        "owner": null,
+        "deadline": "Friday",
+        "priority": "medium",
+        "confidence": 0.95,
+        "sourceQuote": "We agreed to ship the staging cut on Friday."
+      }
+    ],
+    "createdIssues": [],
+    "decisions": [
+      "Ship the staging cut on Friday."
+    ]
+  }
+}

--- a/src/__fixtures__/meeting-context/assistant-question-only.ts
+++ b/src/__fixtures__/meeting-context/assistant-question-only.ts
@@ -1,0 +1,42 @@
+import type { MockMeetingContextBundle } from '../../models.js';
+
+const assistantQuestionOnly: MockMeetingContextBundle = {
+  fixtureId: 'assistant-question-only',
+  description: 'Read-only meeting context for spoken Q&A with no provider writes.',
+  mockContext: {
+    permissions: {
+      github: 'not_needed',
+      calendar: 'not_needed',
+      telegram: 'not_needed',
+    },
+    expectedMode: 'read_only',
+  },
+  session: {
+    meetingId: 'meeting-question-only-001',
+    url: 'https://meet.google.com/question-only-demo',
+    startTime: '2026-04-19T20:45:00.000Z',
+    botId: 'bot-question-only',
+    websocketUrl: 'wss://recall.example.test/meeting-question-only-001',
+    isActive: true,
+    transcriptBuffer: [
+      { speaker: 'Tom', text: 'Claude, what did we decide about the release train?', timestamp: 1713559500000 },
+      { speaker: 'Anna', text: 'We agreed to ship the staging cut on Friday.', timestamp: 1713559560000 },
+    ],
+    intents: [
+      {
+        id: 'intent-decision-1',
+        type: 'DECISION',
+        text: 'Ship the staging cut on Friday',
+        owner: null,
+        deadline: 'Friday',
+        priority: 'medium',
+        confidence: 0.95,
+        sourceQuote: 'We agreed to ship the staging cut on Friday.',
+      },
+    ],
+    createdIssues: [],
+    decisions: ['Ship the staging cut on Friday.'],
+  },
+};
+
+export default assistantQuestionOnly;

--- a/src/__fixtures__/meeting-context/baseline-active-session.json
+++ b/src/__fixtures__/meeting-context/baseline-active-session.json
@@ -1,0 +1,57 @@
+{
+  "fixtureId": "baseline-active-session",
+  "description": "Active product sync with extracted intents and one created GitHub issue.",
+  "mockContext": {
+    "permissions": {
+      "github": "granted",
+      "calendar": "granted",
+      "telegram": "granted"
+    },
+    "expectedMode": "auto"
+  },
+  "session": {
+    "meetingId": "meeting-baseline-001",
+    "url": "https://meet.google.com/baseline-demo",
+    "startTime": "2026-04-19T20:00:00.000Z",
+    "botId": "bot-baseline",
+    "websocketUrl": "wss://recall.example.test/meeting-baseline-001",
+    "isActive": true,
+    "transcriptBuffer": [
+      { "speaker": "Tom", "text": "The mobile login flow is still broken for invited users.", "timestamp": 1713556800000 },
+      { "speaker": "Anna", "text": "Please open a bug and I will update the docs after the call.", "timestamp": 1713556860000 }
+    ],
+    "intents": [
+      {
+        "id": "intent-bug-1",
+        "type": "BUG",
+        "text": "Fix invited-user mobile login flow",
+        "owner": null,
+        "deadline": null,
+        "priority": "high",
+        "confidence": 0.96,
+        "sourceQuote": "The mobile login flow is still broken for invited users."
+      },
+      {
+        "id": "intent-todo-1",
+        "type": "TODO",
+        "text": "Update login troubleshooting docs",
+        "owner": "Anna",
+        "deadline": null,
+        "priority": "medium",
+        "confidence": 0.93,
+        "sourceQuote": "I will update the docs after the call."
+      }
+    ],
+    "createdIssues": [
+      {
+        "intentText": "Fix invited-user mobile login flow",
+        "issueUrl": "https://github.com/Genesis-Archive/meeting-agent/issues/42",
+        "issueNumber": 42,
+        "title": "Bug: invited-user mobile login flow fails"
+      }
+    ],
+    "decisions": [
+      "Treat invited-user mobile login as the top bug for the next sprint."
+    ]
+  }
+}

--- a/src/__fixtures__/meeting-context/baseline-active-session.ts
+++ b/src/__fixtures__/meeting-context/baseline-active-session.ts
@@ -1,0 +1,59 @@
+import type { MockMeetingContextBundle } from '../../models.js';
+
+const baselineActiveSession: MockMeetingContextBundle = {
+  fixtureId: 'baseline-active-session',
+  description: 'Active product sync with extracted intents and one created GitHub issue.',
+  mockContext: {
+    permissions: {
+      github: 'granted',
+      calendar: 'granted',
+      telegram: 'granted',
+    },
+    expectedMode: 'auto',
+  },
+  session: {
+    meetingId: 'meeting-baseline-001',
+    url: 'https://meet.google.com/baseline-demo',
+    startTime: '2026-04-19T20:00:00.000Z',
+    botId: 'bot-baseline',
+    websocketUrl: 'wss://recall.example.test/meeting-baseline-001',
+    isActive: true,
+    transcriptBuffer: [
+      { speaker: 'Tom', text: 'The mobile login flow is still broken for invited users.', timestamp: 1713556800000 },
+      { speaker: 'Anna', text: 'Please open a bug and I will update the docs after the call.', timestamp: 1713556860000 },
+    ],
+    intents: [
+      {
+        id: 'intent-bug-1',
+        type: 'BUG',
+        text: 'Fix invited-user mobile login flow',
+        owner: null,
+        deadline: null,
+        priority: 'high',
+        confidence: 0.96,
+        sourceQuote: 'The mobile login flow is still broken for invited users.',
+      },
+      {
+        id: 'intent-todo-1',
+        type: 'TODO',
+        text: 'Update login troubleshooting docs',
+        owner: 'Anna',
+        deadline: null,
+        priority: 'medium',
+        confidence: 0.93,
+        sourceQuote: 'I will update the docs after the call.',
+      },
+    ],
+    createdIssues: [
+      {
+        intentText: 'Fix invited-user mobile login flow',
+        issueUrl: 'https://github.com/Genesis-Archive/meeting-agent/issues/42',
+        issueNumber: 42,
+        title: 'Bug: invited-user mobile login flow fails',
+      },
+    ],
+    decisions: ['Treat invited-user mobile login as the top bug for the next sprint.'],
+  },
+};
+
+export default baselineActiveSession;

--- a/src/__fixtures__/meeting-context/calendar-permission-denied.json
+++ b/src/__fixtures__/meeting-context/calendar-permission-denied.json
@@ -1,0 +1,40 @@
+{
+  "fixtureId": "calendar-permission-denied",
+  "description": "Meeting context where a follow-up sync is requested but calendar write access is unavailable.",
+  "mockContext": {
+    "permissions": {
+      "github": "granted",
+      "calendar": "denied",
+      "telegram": "granted"
+    },
+    "expectedMode": "manual_review"
+  },
+  "session": {
+    "meetingId": "meeting-calendar-denied-001",
+    "url": "https://meet.google.com/calendar-denied-demo",
+    "startTime": "2026-04-19T20:30:00.000Z",
+    "botId": "bot-calendar-denied",
+    "websocketUrl": "wss://recall.example.test/meeting-calendar-denied-001",
+    "isActive": true,
+    "transcriptBuffer": [
+      { "speaker": "Anna", "text": "Let's schedule a thirty minute bug triage tomorrow morning.", "timestamp": 1713558600000 },
+      { "speaker": "Claude", "text": "I noted the request, but calendar permissions are not available.", "timestamp": 1713558660000 }
+    ],
+    "intents": [
+      {
+        "id": "intent-meeting-1",
+        "type": "MEETING_REQUEST",
+        "text": "Schedule a thirty minute bug triage tomorrow morning",
+        "owner": null,
+        "deadline": "tomorrow morning",
+        "priority": "medium",
+        "confidence": 0.91,
+        "sourceQuote": "Let's schedule a thirty minute bug triage tomorrow morning."
+      }
+    ],
+    "createdIssues": [],
+    "decisions": [
+      "Calendar follow-up stays manual until write access is approved."
+    ]
+  }
+}

--- a/src/__fixtures__/meeting-context/calendar-permission-denied.ts
+++ b/src/__fixtures__/meeting-context/calendar-permission-denied.ts
@@ -1,0 +1,42 @@
+import type { MockMeetingContextBundle } from '../../models.js';
+
+const calendarPermissionDenied: MockMeetingContextBundle = {
+  fixtureId: 'calendar-permission-denied',
+  description: 'Meeting context where a follow-up sync is requested but calendar write access is unavailable.',
+  mockContext: {
+    permissions: {
+      github: 'granted',
+      calendar: 'denied',
+      telegram: 'granted',
+    },
+    expectedMode: 'manual_review',
+  },
+  session: {
+    meetingId: 'meeting-calendar-denied-001',
+    url: 'https://meet.google.com/calendar-denied-demo',
+    startTime: '2026-04-19T20:30:00.000Z',
+    botId: 'bot-calendar-denied',
+    websocketUrl: 'wss://recall.example.test/meeting-calendar-denied-001',
+    isActive: true,
+    transcriptBuffer: [
+      { speaker: 'Anna', text: "Let's schedule a thirty minute bug triage tomorrow morning.", timestamp: 1713558600000 },
+      { speaker: 'Claude', text: 'I noted the request, but calendar permissions are not available.', timestamp: 1713558660000 },
+    ],
+    intents: [
+      {
+        id: 'intent-meeting-1',
+        type: 'MEETING_REQUEST',
+        text: 'Schedule a thirty minute bug triage tomorrow morning',
+        owner: null,
+        deadline: 'tomorrow morning',
+        priority: 'medium',
+        confidence: 0.91,
+        sourceQuote: "Let's schedule a thirty minute bug triage tomorrow morning.",
+      },
+    ],
+    createdIssues: [],
+    decisions: ['Calendar follow-up stays manual until write access is approved.'],
+  },
+};
+
+export default calendarPermissionDenied;

--- a/src/__fixtures__/meeting-context/github-permission-denied.json
+++ b/src/__fixtures__/meeting-context/github-permission-denied.json
@@ -1,0 +1,40 @@
+{
+  "fixtureId": "github-permission-denied",
+  "description": "Meeting context where GitHub issue creation is blocked by missing permission.",
+  "mockContext": {
+    "permissions": {
+      "github": "denied",
+      "calendar": "granted",
+      "telegram": "granted"
+    },
+    "expectedMode": "manual_review"
+  },
+  "session": {
+    "meetingId": "meeting-github-denied-001",
+    "url": "https://meet.google.com/github-denied-demo",
+    "startTime": "2026-04-19T20:15:00.000Z",
+    "botId": "bot-github-denied",
+    "websocketUrl": "wss://recall.example.test/meeting-github-denied-001",
+    "isActive": true,
+    "transcriptBuffer": [
+      { "speaker": "Tom", "text": "Can someone log the auth callback bug in GitHub?", "timestamp": 1713557700000 },
+      { "speaker": "Claude", "text": "I can capture it for review, but GitHub permissions are missing.", "timestamp": 1713557760000 }
+    ],
+    "intents": [
+      {
+        "id": "intent-bug-2",
+        "type": "BUG",
+        "text": "Investigate auth callback failure after OAuth redirect",
+        "owner": null,
+        "deadline": null,
+        "priority": "high",
+        "confidence": 0.94,
+        "sourceQuote": "Can someone log the auth callback bug in GitHub?"
+      }
+    ],
+    "createdIssues": [],
+    "decisions": [
+      "Keep auth callback bug in the meeting summary until GitHub access is restored."
+    ]
+  }
+}

--- a/src/__fixtures__/meeting-context/github-permission-denied.ts
+++ b/src/__fixtures__/meeting-context/github-permission-denied.ts
@@ -1,0 +1,42 @@
+import type { MockMeetingContextBundle } from '../../models.js';
+
+const githubPermissionDenied: MockMeetingContextBundle = {
+  fixtureId: 'github-permission-denied',
+  description: 'Meeting context where GitHub issue creation is blocked by missing permission.',
+  mockContext: {
+    permissions: {
+      github: 'denied',
+      calendar: 'granted',
+      telegram: 'granted',
+    },
+    expectedMode: 'manual_review',
+  },
+  session: {
+    meetingId: 'meeting-github-denied-001',
+    url: 'https://meet.google.com/github-denied-demo',
+    startTime: '2026-04-19T20:15:00.000Z',
+    botId: 'bot-github-denied',
+    websocketUrl: 'wss://recall.example.test/meeting-github-denied-001',
+    isActive: true,
+    transcriptBuffer: [
+      { speaker: 'Tom', text: 'Can someone log the auth callback bug in GitHub?', timestamp: 1713557700000 },
+      { speaker: 'Claude', text: 'I can capture it for review, but GitHub permissions are missing.', timestamp: 1713557760000 },
+    ],
+    intents: [
+      {
+        id: 'intent-bug-2',
+        type: 'BUG',
+        text: 'Investigate auth callback failure after OAuth redirect',
+        owner: null,
+        deadline: null,
+        priority: 'high',
+        confidence: 0.94,
+        sourceQuote: 'Can someone log the auth callback bug in GitHub?',
+      },
+    ],
+    createdIssues: [],
+    decisions: ['Keep auth callback bug in the meeting summary until GitHub access is restored.'],
+  },
+};
+
+export default githubPermissionDenied;

--- a/src/__fixtures__/meeting-context/index.ts
+++ b/src/__fixtures__/meeting-context/index.ts
@@ -1,0 +1,20 @@
+import type { MockMeetingContextBundle } from '../../models.js';
+
+import assistantQuestionOnly from './assistant-question-only.js';
+import baselineActiveSession from './baseline-active-session.js';
+import calendarPermissionDenied from './calendar-permission-denied.js';
+import githubPermissionDenied from './github-permission-denied.js';
+
+export {
+  assistantQuestionOnly,
+  baselineActiveSession,
+  calendarPermissionDenied,
+  githubPermissionDenied,
+};
+
+export const meetingContextFixtures: MockMeetingContextBundle[] = [
+  assistantQuestionOnly,
+  baselineActiveSession,
+  calendarPermissionDenied,
+  githubPermissionDenied,
+];

--- a/src/__tests__/mock-context-fixtures.test.ts
+++ b/src/__tests__/mock-context-fixtures.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MockMeetingContextBundle } from '../models.js';
+import assistantQuestionOnly from '../__fixtures__/meeting-context/assistant-question-only.js';
+import baselineActiveSession from '../__fixtures__/meeting-context/baseline-active-session.js';
+import calendarPermissionDenied from '../__fixtures__/meeting-context/calendar-permission-denied.js';
+import githubPermissionDenied from '../__fixtures__/meeting-context/github-permission-denied.js';
+
+const fixtures: MockMeetingContextBundle[] = [
+  assistantQuestionOnly,
+  baselineActiveSession,
+  calendarPermissionDenied,
+  githubPermissionDenied,
+];
+
+describe('meeting context fixtures', () => {
+  it('all fixtures match the expected typed meeting-context bundle shape', () => {
+    for (const fixture of fixtures) {
+      expect(fixture.fixtureId.length).toBeGreaterThan(0);
+      expect(fixture.description.length).toBeGreaterThan(0);
+      expect(fixture.session.url.startsWith('https://')).toBe(true);
+      expect(Number.isFinite(Date.parse(fixture.session.startTime))).toBe(true);
+    }
+  });
+
+  it('covers the baseline, read-only, and denied-permission cases needed for mock context tests', () => {
+    const fixtureIds = new Set(fixtures.map((fixture) => fixture.fixtureId));
+
+    expect(fixtureIds).toEqual(new Set([
+      'assistant-question-only',
+      'baseline-active-session',
+      'calendar-permission-denied',
+      'github-permission-denied',
+    ]));
+  });
+
+  it('keeps denied-permission cases in manual review mode instead of auto execution', () => {
+    const deniedCases = fixtures.filter((fixture) =>
+      Object.values(fixture.mockContext.permissions).includes('denied'),
+    );
+
+    expect(deniedCases).toHaveLength(2);
+    expect(deniedCases.every((fixture) => fixture.mockContext.expectedMode === 'manual_review')).toBe(true);
+  });
+
+  it('keeps the assistant-question-only fixture free of write-required integrations', () => {
+    expect(assistantQuestionOnly.mockContext.permissions).toEqual({
+      github: 'not_needed',
+      calendar: 'not_needed',
+      telegram: 'not_needed',
+    });
+    expect(assistantQuestionOnly.mockContext.expectedMode).toBe('read_only');
+  });
+});

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -11,6 +11,11 @@ import type {
   CreatedIssue,
   TranscriptSegment,
   MeetingSummary,
+  PermissionState,
+  MockContextMode,
+  SerializedMeetingSession,
+  MockMeetingContext,
+  MockMeetingContextBundle,
 } from './models.js';
 
 describe('models', () => {
@@ -122,6 +127,20 @@ describe('models', () => {
     });
   });
 
+  describe('PermissionState', () => {
+    it('accepts all valid permission states', () => {
+      const states: PermissionState[] = ['granted', 'denied', 'not_needed'];
+      expect(states).toHaveLength(3);
+    });
+  });
+
+  describe('MockContextMode', () => {
+    it('accepts all supported mock execution modes', () => {
+      const modes: MockContextMode[] = ['auto', 'manual_review', 'read_only'];
+      expect(modes).toHaveLength(3);
+    });
+  });
+
   describe('MeetingSummary', () => {
     it('has the correct shape with all required fields', () => {
       const now = new Date();
@@ -180,6 +199,60 @@ describe('models', () => {
       expect(summary.createdIssues).toHaveLength(1);
       expect(summary.createdIssues[0]).toBe(issue);
       expect(summary.decisions).toEqual(['Ship dark mode by Q3']);
+    });
+  });
+
+  describe('SerializedMeetingSession and MockMeetingContextBundle', () => {
+    it('captures the serialized session shape used by mock fixtures', () => {
+      const session: SerializedMeetingSession = {
+        meetingId: 'meeting-serialized-001',
+        url: 'https://meet.google.com/mock-bundle-demo',
+        startTime: '2026-04-19T20:00:00.000Z',
+        botId: 'bot-serialized',
+        websocketUrl: 'wss://recall.example.test/mock-bundle-demo',
+        isActive: true,
+        transcriptBuffer: [{ text: 'Status?', speaker: 'Tom', timestamp: 1713556800000 }],
+        intents: [],
+        createdIssues: [],
+        decisions: ['Keep typed fixtures aligned with MeetingSession#toJSON.'],
+      };
+
+      expect(session.meetingId).toBe('meeting-serialized-001');
+      expect(session.transcriptBuffer).toHaveLength(1);
+      expect(session.decisions[0]).toContain('typed fixtures');
+    });
+
+    it('captures mock fixture metadata alongside the serialized session payload', () => {
+      const mockContext: MockMeetingContext = {
+        permissions: {
+          github: 'granted',
+          calendar: 'denied',
+          telegram: 'not_needed',
+        },
+        expectedMode: 'manual_review',
+      };
+
+      const bundle: MockMeetingContextBundle = {
+        fixtureId: 'typed-bundle-demo',
+        description: 'Typed mock meeting bundle',
+        mockContext,
+        session: {
+          meetingId: 'meeting-serialized-002',
+          url: 'https://meet.google.com/typed-bundle-demo',
+          startTime: '2026-04-19T21:00:00.000Z',
+          botId: null,
+          websocketUrl: null,
+          isActive: false,
+          transcriptBuffer: [],
+          intents: [],
+          createdIssues: [],
+          decisions: [],
+        },
+      };
+
+      expect(bundle.mockContext.expectedMode).toBe('manual_review');
+      expect(bundle.mockContext.permissions.calendar).toBe('denied');
+      expect(bundle.session.isActive).toBe(false);
     });
   });
 });

--- a/src/models.ts
+++ b/src/models.ts
@@ -40,3 +40,35 @@ export interface MeetingSummary {
   decisions: string[];
   markdown: string;
 }
+
+export type PermissionState = 'granted' | 'denied' | 'not_needed';
+export type MockContextMode = 'auto' | 'manual_review' | 'read_only';
+
+export interface SerializedMeetingSession {
+  meetingId: string;
+  url: string;
+  startTime: string;
+  botId: string | null;
+  websocketUrl: string | null;
+  isActive: boolean;
+  transcriptBuffer: TranscriptSegment[];
+  intents: Intent[];
+  createdIssues: CreatedIssue[];
+  decisions: string[];
+}
+
+export interface MockMeetingContext {
+  permissions: {
+    github: PermissionState;
+    calendar: PermissionState;
+    telegram: PermissionState;
+  };
+  expectedMode: MockContextMode;
+}
+
+export interface MockMeetingContextBundle {
+  fixtureId: string;
+  description: string;
+  mockContext: MockMeetingContext;
+  session: SerializedMeetingSession;
+}


### PR DESCRIPTION
## Summary
- add typed mock meeting-context bundle models plus fixture coverage for baseline, denied-permission, and read-only cases
- add a fixture-focused test that locks the bundle shape and the expected permission modes
- publish the current planning and approval docs for the browser-capture to artifact lane

## Validation
- `npm test`
  - passes: new fixture coverage and the broader suite except for the existing `src/__tests__/plugin.test.ts` route-registration failures
  - known existing failures observed: 6 tests in `src/__tests__/plugin.test.ts`

## Notes
- This PR was published through a direct GitHub-capable fallback path from the local finished branch state because the Paperclip API was timing out during the run.